### PR TITLE
Add WSL guide and launch file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://github.com/user-attachments/assets/0c60afc0-22bf-4ea0-b367-8691ecf6a3e7
 > [!IMPORTANT]
 > This stack is developed and tested using a [Ubuntu 22.04](https://ubuntu.com/about/release-cycle) host (penultimate LTS, ESM 4/2032) with [**`nvidia-driver-575`**](https://developer.nvidia.com/datacenter-driver-archive) and Docker Engine v28 (latest stable releases as of 7/2025) on an i9-13 with RTX3500 and an i7-11 with RTX3060—**note that an NVIDIA GPU *is* required**
 > 
-> **To setup the requirements: (i) Ubuntu 22, Git LFS, (ii) NVIDIA driver, (iii) Docker Engine, (iv) NVIDIA Container Toolkit, and (v) NVIDIA NGC API Key, read [`PREINSTALL.md`](/supplementary/PREINSTALL.md)**
+> **To setup the requirements: (i) Ubuntu 22, Git LFS, (ii) NVIDIA driver, (iii) Docker Engine, (iv) NVIDIA Container Toolkit, and (v) NVIDIA NGC API Key, read [`PREINSTALL.md`](/supplementary/PREINSTALL.md). For windows builds, read [`WSL.md`](/supplementary/WSL.md)**
 
 ```sh
 # Clone this repo
@@ -75,6 +75,19 @@ DRONE_TYPE=quad AUTOPILOT=px4 NUM_DRONES=2 WORLD=swiss_town ./sim_run.sh # Check
 > On a low-mid range laptop (i7-11 with 16GB RAM and RTX3060), AAS can simulate 3 drones with camera and LiDAR at 70-80% of the wall-clock
 >
 > Once "Ready to Fly", one can takeoff and control from QGroundControl's ["Fly View"](https://docs.qgroundcontrol.com/master/en/qgc-user-guide/fly_view/fly_view.html)
+
+> [!NOTE]
+> <details>
+> <summary>Simulation for Windows-based build (WSL): <i>(expand)</i></summary>
+> On a native Linux desktop, the simulation scripts use **`gnome-terminal`** to spawn multiple windows (one for the simulator and one for each aircraft).  
+> For WSL2, we use **`xterm`**, a lightweight X11 terminal emulator, where graphical applications are forwarded to Windows through an external X server (such as VcXsrv or Xming on Windows).  
+> 
+> To start the simulation in WSL2, use the `sim_run.sh` script located in `/scripts/xterm`:
+> ```sh
+> cd ~/git/aerial-autonomy-stack/scripts/xterm
+> DRONE_TYPE=quad AUTOPILOT=px4 NUM_DRONES=2 WORLD=swiss_town ./sim_run.sh
+> ```
+</details>
 
 ![worlds](https://github.com/user-attachments/assets/45a2f2ad-cc31-4d71-aa2e-4fe542a59a77)
 

--- a/scripts/xterm/sim_run.sh
+++ b/scripts/xterm/sim_run.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+# Set up the simulation
+DRONE_TYPE="${DRONE_TYPE:-quad}" # Options: quad (default), vtol
+AUTOPILOT="${AUTOPILOT:-px4}" # Options: px4 (default), ardupilot
+NUM_DRONES="${NUM_DRONES:-1}" # Number of aircraft (default = 1)
+WORLD="${WORLD:-impalpable_greyness}" # Options: impalpable_greyness (default), apple_orchard, shibuya_crossing, swiss_town
+HEADLESS="${HEADLESS:-false}" # Options: true, false (default)
+CAMERA="${CAMERA:-true}" # Options: true (default), false
+LIDAR="${LIDAR:-true}" # Options: true (default), false 
+MODE="${MODE:-}" # Options: empty (default), dev, ...
+
+# Initialize an empty variable for the flags
+MODE_SIM_OPTS=""
+MODE_AIR_OPTS=""
+if [[ "$MODE" == "dev" ]]; then
+    SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    MODE_SIM_OPTS="--entrypoint /bin/bash"
+    MODE_SIM_OPTS+=" -v ${SCRIPT_DIR}/../simulation/simulation_resources/:/simulation_resources:cached"
+    MODE_SIM_OPTS+=" -v ${SCRIPT_DIR}/../simulation/simulation_ws/src:/ros2_ws/src:cached"
+    MODE_AIR_OPTS="--entrypoint /bin/bash"
+    MODE_AIR_OPTS+=" -v ${SCRIPT_DIR}/../aircraft/aircraft_resources/:/aircraft_resources:cached"
+    MODE_AIR_OPTS+=" -v ${SCRIPT_DIR}/../aircraft/aircraft_ws/src:/ros2_ws/src:cached"
+    MODE_AIR_OPTS+=" -v ${SCRIPT_DIR}/../simulation/simulation_ws/src/ground_system_msgs:/ros2_ws/src/ground_system_msgs:cached"
+fi
+
+# Grant access to the X server
+export DISPLAY=${DISPLAY:-$(grep nameserver /etc/resolv.conf | awk '{print $2}'):0}
+export LIBGL_ALWAYS_INDIRECT=1
+export QT_X11_NO_MITSHM=1
+if command -v xhost >/dev/null 2>&1; then xhost +local:; fi
+
+# Create network
+NETWORK_NAME="aas-network"
+docker network inspect "$NETWORK_NAME" >/dev/null 2>&1 || docker network create "$NETWORK_NAME"
+
+# Launch the simulation container
+xterm -T "Simulation" -e "docker run -it --rm \
+  --volume /tmp/.X11-unix:/tmp/.X11-unix:rw --device /dev/dri --gpus all \
+  --env DISPLAY=$DISPLAY --env QT_X11_NO_MITSHM=1 --env NVIDIA_DRIVER_CAPABILITIES=all \
+  --env ROS_DOMAIN_ID=99 --env AUTOPILOT=$AUTOPILOT --env DRONE_TYPE=$DRONE_TYPE \
+  --env NUM_DRONES=$NUM_DRONES --env WORLD=$WORLD --env HEADLESS=$HEADLESS --env CAMERA=$CAMERA --env LIDAR=$LIDAR \
+  --env SIMULATED_TIME=true \
+  --net $NETWORK_NAME --ip 42.42.1.99 --privileged --name simulation-container \
+  $MODE_SIM_OPTS simulation-image; bash"
+
+# Launch the aircraft containers
+for i in $(seq 1 $NUM_DRONES); do
+    sleep 1.5
+    xterm -T "Aircraft $i" -e "docker run -it --rm \
+      --volume /tmp/.X11-unix:/tmp/.X11-unix:rw --device /dev/dri --gpus all \
+      --env DISPLAY=$DISPLAY --env QT_X11_NO_MITSHM=1 --env NVIDIA_DRIVER_CAPABILITIES=all \
+      --env ROS_DOMAIN_ID=$i --env AUTOPILOT=$AUTOPILOT --env DRONE_TYPE=$DRONE_TYPE \
+      --env DRONE_ID=$i --env HEADLESS=$HEADLESS --env CAMERA=$CAMERA --env LIDAR=$LIDAR \
+      --env SIMULATED_TIME=true \
+      --net $NETWORK_NAME --ip 42.42.1.$i --privileged --name aircraft-container_$i \
+      $MODE_AIR_OPTS aircraft-image; bash"
+done
+
+echo "Fly, my pretties, fly!"

--- a/supplementary/WSL.md
+++ b/supplementary/WSL.md
@@ -1,0 +1,167 @@
+# Pre-installation for WSL builds
+
+## Install WSL 
+The [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) lets developers install a Linux distribution (such as Ubuntu, OpenSUSE, Kali, Debian, Arch Linux, etc) and use Linux applications, utilities, and Bash command-line tools directly on Windows, unmodified, without the overhead of a traditional virtual machine or dualboot setup.
+
+> [!NOTE]
+> You must be running Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11 to use the commands below. If you are on earlier versions please see [the manual install page](https://learn.microsoft.com/en-us/windows/wsl/install-manual).
+
+- From PowerShell, check available Linux distributions `wsl --list --online`
+- Install "Ubuntu-22.04" `wsl --install -d Ubuntu-22.04`
+- Enter new `UNIX username` and `Password`
+
+```sh
+# Install git
+sudo apt update
+sudo apt upgrade
+sudo apt install git
+
+# Install git-lfs (for the large files in simulation_resources/)
+sudo apt install git-lfs
+git lfs install
+
+# Install xterm
+sudo apt update
+sudo apt install xterm -y
+
+# Create an ssh key (optional)
+ssh-keygen 
+cat ~/.ssh/id_rsa.pub
+```
+
+> [!IMPORTANT]
+> When building and running large Docker images (e.g. the simulator and aircraft containers), WSL2 can easily consume available system resources. To prevent crashes, hangs, or 100% disk usage, we configure WSL2’s resource limits using a **`.wslconfig`** file. 
+> 
+> ```sh
+> # From **Windows user home directory**: 
+> # Create (or edit) the file `C:\Users\<YourWindowsUsername>\.wslconfig` and add:
+>
+> [wsl2]
+> memory=10GB
+> processors=8
+> swap=16GB
+> swapfile=C:\\Users\\<YourWindowsUsername>\\AppData\\Local\\Temp\\wsl-swap.vhdx
+> localhostForwarding=true
+>
+> # After editing .wslconfig, restart WSL for the new settings to take effect:
+> wsl --shutdown 
+>
+> # To check available memory and swap, open your WSL2 distro and run:
+> free -h
+> ```
+> For additinal resources please see [advanced settings configuration.](https://learn.microsoft.com/en-us/windows/wsl/wsl-config)
+
+## Enable NVIDIA CUDA on WSL
+Download and install the [NVIDIA CUDA enabled driver for WSL](https://www.nvidia.com/download/index.aspx) 
+
+>[!NOTE] 
+>The latest NVIDIA Windows GPU driver fully supports **WSL 2**, enabling existing CUDA applications compiled on Linux to run unmodified in WSL.
+Once the Windows NVIDIA GPU driver is installed, CUDA is available in WSL 2 via a stubbed `libcuda.so`. **Users must not install a separate NVIDIA GPU Linux driver inside WSL 2**,
+
+- On **WSL 2 with NVIDIA GPU driver installed**, OpenGL is accelerated through **DirectX + GPU driver interop** (via WSLg).
+
+```sh
+# From WSL, check NVIDIA GPU
+nvidia-smi
+
+# Install Mesa utilities, for gz sim rendering 
+sudo apt update
+sudo apt install -y mesa-utils
+glxinfo | grep "OpenGL renderer"
+
+# If GPU acceleration is working, you should see something like: `OpenGL renderer string: D3D12 (Intel(R) UHD Graphics)`
+
+# For CUDA workloads, WSL doesn’t rely on `glxinfo`. Instead it uses the NVIDIA Windows driver stubbed inside WSL (`libcuda.so`). So you can still have full CUDA even though OpenGL shows Intel. This only shows the renderer used for graphics (OpenGL), **not CUDA compute**.
+```
+
+## Install Docker Engine and NVIDIA Container Toolkit
+
+> [!NOTE]
+> Skip this step if you already installed **Docker Engine and NVIDIA Container Toolkit**
+
+```sh
+# Based on https://docs.docker.com/engine/install/ubuntu/ and https://docs.docker.com/engine/install/linux-postinstall/
+
+for pkg in docker.io docker-doc docker-compose docker-compose-v2 podman-docker containerd runc; do sudo apt-get remove $pkg; done # none should be there
+
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+```
+
+```sh
+# Install and test Docker Engine
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo docker run hello-world
+sudo docker version # 28.3.0 at the time of writing
+					
+
+# Remove the need to sudo the docker command
+sudo groupadd docker
+sudo usermod -aG docker $USER
+newgrp docker # Reboot
+docker run hello-world
+```
+
+Log in to the NVIDIA Registry:
+
+- Go to https://ngc.nvidia.com and login/create an account.
+- Click on your account the top right, go to Setup -> Get API Key.
+- Click "Generate API Key" -> "+ Generate Personal Key" for the "NCG Catalog" service, confirm, and copy the key.
+
+```sh
+docker login nvcr.io # To be able to reliably pull NVIDIA base images
+Username: # type $oauthtoken
+Password: # copy and paste the API key and press enter to pull base images from nvcr.io/
+```
+
+```sh
+# Add NVIDIA Container Toolkit to use the GPU within containers
+distribution=$(. /etc/os-release;echo $ID$VERSION_ID)
+curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+curl -s -L https://nvidia.github.io/nvidia-docker/$distribution/nvidia-docker.list | sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+sudo apt update
+sudo apt install -y nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+
+# Check `nvidia` runtime is available
+docker info | grep -i runtime
+
+# Test with
+docker run --rm --gpus all nvidia/cuda:12.2.0-base-ubuntu22.04 nvidia-smi
+```
+
+## Install VcXsrv Windows X Server
+WSL2 does not provide a full Linux desktop environment by default, so graphical applications (like Gazebo or other GUI tools) cannot run natively. To display GUI applications from WSL2 on Windows, we need an X server. VcXsrv is a lightweight and widely used X server for Windows.
+- Download [VcXsrv:](https://sourceforge.net/projects/vcxsrv/) and download the installer.
+- Run the installer with default settings.
+    - Start “XLaunch” (comes with VcXsrv).
+    - Choose Multiple windows.
+    - Set Display number to 0.
+    - Check Start no client.
+    - Check Disable access control (or configure for security).
+    - Finish to launch the X server.
+
+From your WSL2 terminal, you should configure your `~/.bashrc` file to set up the display and X11 permissions automatically whenever you open a WSL terminal.
+
+> ```sh
+> # WSL2 GUI setup
+> echo 'export DISPLAY=$(grep nameserver /etc/resolv.conf | awk "{print \$2}"):0' >> ~/.bashrc
+> echo 'export LIBGL_ALWAYS_INDIRECT=1' >> ~/.bashrc
+> echo 'export QT_X11_NO_MITSHM=1' >> ~/.bashrc
+> echo 'if command -v xhost >/dev/null 2>&1; then xhost +local:; fi' >> ~/.bashrc
+>
+> # Reload .bashrc
+> source ~/.bashrc
+> ```


### PR DESCRIPTION
This pull request adds a WSL setup guide and a launch file for running the simulation environment.

Changes included:
- Added `supplementary/WSL.md` detailing WSL installation, configuration, and usage.
- Added `scripts/xterm/sim_run.sh` launch script for starting simulations.
- Updated `README.md` with references to the WSL guide and instructions for running the simulation.

These updates provide clear instructions for using WSL and automate the simulation launch process.

Tested on:
- Host: Windows 11 Pro, ASUSTeK ROG Strix G614JU
- CPU: Intel Core i9-13980HX
- GPU: NVIDIA RTX 4050 Laptop GPU / Intel UHD Graphics
- Memory: 16 GiB RAM
- WSL2 with Ubuntu 22.04.5 LTS
- Swap: 16 GiB