### PR TITLE
Add Gymnasium RL interface and stable-baselines3 RL examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,6 @@ docker exec -it aircraft-container tmux attach
 
 ## Future Work / Ideas for Contributions
 
-- [Gymnasium](https://github.com/Farama-Foundation/Gymnasium) RL interface
 - Support for [SPARK-FAST-LIO](https://github.com/MIT-SPARK/spark-fast-lio)/[SuperOdom](https://github.com/superxslam/SuperOdom)
 - Support for [JSBSim](https://github.com/JSBSim-Team/jsbsim) flight dynamics
 - Support for [ArduPilot's DDS interface](https://ardupilot.org/dev/docs/ros2-interfaces.html)


### PR DESCRIPTION
Roadmap
- allow parallel execution of multiple `sim_run.sh` (using different `docker network` subnets)
- Python-wrap the STIL environment in a [`gymnasium.Env`](https://gymnasium.farama.org/introduction/create_custom_env/) class 
- Determine a range of useful simulation steps (1Hz for high level actions, 50Hz for offboard references) 
- Determine the observation space and sample it (e.g. using `docker exec` to echo ROS2 topics)
- Determine the action space and implement it (e.g. using `docker exec` to start ROS2 actions or publish offboard references topics)
- Add a reward signal with customizable implementation
- Create a [`stable-baselines3`](https://stable-baselines3.readthedocs.io/en/master/guide/quickstart.html) example for a navigation task