### PR TITLE
Ubuntu 24 and ROS2 Jazzy Docker Images

### DIFF
--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04 AS base_amd64
+FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04 AS base_amd64
 FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0 AS base_arm64
 ################################################################################
 # Stage 1 - 8GB ################################################################
@@ -18,8 +18,8 @@ RUN apt update \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ROS2 Humble
-# Based on https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html
+# Install ROS2 Jazzy
+# Based on https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html
 RUN apt update \
     && apt install -y --no-install-recommends \
         locales \
@@ -38,12 +38,12 @@ RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/r
     $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
 RUN apt update \
     && apt install -y --no-install-recommends \
-        ros-humble-desktop ros-dev-tools \
-        ros-humble-bondcpp ros-humble-ament-cmake-clang-format \
-        ros-humble-vision-msgs \
+        ros-jazzy-desktop ros-dev-tools \
+        ros-jazzy-bondcpp ros-jazzy-ament-cmake-clang-format \
+        ros-jazzy-vision-msgs \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
-RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc
+RUN echo "source /opt/ros/jazzy/setup.bash" >> /root/.bashrc
 RUN rosdep init
 
 ################################################################################
@@ -55,9 +55,9 @@ FROM ros2-image AS ros2-px4msgs-image
 COPY /github_clones/px4_msgs /ros2_ws_github/src/px4_msgs
 WORKDIR /ros2_ws_github
 RUN rosdep update
-RUN rosdep install --from-paths src --ignore-src --rosdistro humble -y
+RUN rosdep install --from-paths src --ignore-src --rosdistro jazzy -y
 # Explicitly use bash, not sh, to source and build the workspace
-RUN bash -c "source /opt/ros/humble/setup.bash && colcon build --symlink-install"
+RUN bash -c "source /opt/ros/jazzy/setup.bash && colcon build --symlink-install"
 
 ################################################################################
 # Stage 3 - 8.5GB ##############################################################
@@ -81,11 +81,13 @@ RUN mkdir build && cd build && \
 FROM ros2-px4msgs-dds-image AS ros2-px4msgs-dds-mavros-image
 
 # MAVROS
-RUN apt-get update && \
-    apt-get install -y ros-humble-mavros ros-humble-mavros-extras ros-humble-mavros-msgs \
+RUN apt-get update --allow-releaseinfo-change || (sleep 30 && apt-get update --allow-releaseinfo-change) && \
+    apt-get install -y ros-jazzy-mavros ros-jazzy-mavros-extras ros-jazzy-mavros-msgs \
+        libgeographiclib-dev  \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
-RUN /opt/ros/humble/lib/mavros/install_geographiclib_datasets.sh
+
+RUN /opt/ros/jazzy/lib/mavros/install_geographiclib_datasets.sh
 # Run with $ ros2 launch mavros apm.launch fcu_url:=[URI]
 
 ################################################################################
@@ -97,7 +99,7 @@ FROM ros2-px4msgs-dds-mavros-image AS ros2-px4msgs-dds-mavros-yolo-image
 # See https://github.com/ultralytics/ultralytics/blob/main/README.md and https://onnxruntime.ai/getting-started
 RUN python3 -m venv /yolo-env
 RUN /yolo-env/bin/pip3 install --no-cache-dir --upgrade pip && \
-    /yolo-env/bin/pip3 install --no-cache-dir --resume-retries 5 ultralytics onnx
+    /yolo-env/bin/pip3 install --no-cache-dir ultralytics onnx
 # Check YOLO with $ /yolo-env/bin/python3 -c "import ultralytics; print(ultralytics.__version__)"
 
 # Save the model weights (ONNX, Opset 12), class names, and download a sample video for testing
@@ -117,8 +119,7 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/*
 
 # NOTE: we want system Python's OpenCV to have GStreamer support
-RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir --resume-retries 5 "numpy<2"
+RUN pip3 install --no-cache-dir "numpy<2" --break-system-packages
 # Check with $ python3 -c "import cv2; print(cv2.getBuildInformation())"
 # Versus $ /yolo-env/bin/python3 -c "import cv2; print(cv2.getBuildInformation())"
 
@@ -127,8 +128,7 @@ RUN pip3 install --no-cache-dir --upgrade pip \
 ################################################################################
 FROM ros2-px4msgs-dds-mavros-yolo-image AS image-with-onnxruntime-gpu_amd64
 # Add ONNX Runtime with GPU (CUDA) support for system Python
-RUN pip3 install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir --resume-retries 5 onnxruntime-gpu
+RUN pip3 install --no-cache-dir onnxruntime-gpu --break-system-packages
 # Check with $ python3 -c "import onnxruntime as ort; print(ort.__version__); print(ort.get_available_providers())"
 
 FROM ros2-px4msgs-dds-mavros-yolo-image AS image-with-onnxruntime-gpu_arm64
@@ -142,7 +142,7 @@ RUN apt update && \
     apt install -y --no-install-recommends \
         build-essential software-properties-common libopenblas-dev \
         libpython3.10-dev python3-pip python3-dev python3-setuptools python3-wheel && \
-    pip3 install --no-cache-dir --upgrade "cmake>=3.28" && \
+    pip3 install --no-cache-dir --upgrade "cmake>=3.28" --break-system-packages && \
     cd /git/onnxruntime/ && \
     CUDACXX="/usr/local/cuda/bin/nvcc" ./build.sh --config Release --update --build --parallel --build_wheel \
         --use_tensorrt --cuda_home /usr/local/cuda --cudnn_home /usr/lib/aarch64-linux-gnu \
@@ -153,7 +153,7 @@ RUN apt update && \
         'CMAKE_POLICY_VERSION_MINIMUM=3.5' \
         --allow_running_as_root && \
     cd /git/onnxruntime/build/Linux/Release/dist && \
-    pip3 install onnxruntime_gpu-1.22.1-cp310-cp310-linux_aarch64.whl && \
+    pip3 install onnxruntime_gpu-1.22.1-cp310-cp310-linux_aarch64.whl --break-system-packages && \
     cd /git/onnxruntime/build/Linux/Release && \
     sudo make install && \
     sudo ldconfig && \
@@ -168,20 +168,19 @@ ENV PYTHONPATH=/git/onnxruntime/build/Linux/Release
 FROM image-with-onnxruntime-gpu_${TARGETARCH} AS ros2-px4msgs-dds-mavros-yolo-kissicp-zenoh-image
 
 # Install KISS-ICP
-RUN pip3 install --no-cache-dir --upgrade "cmake>=3.24"
+RUN pip3 install --no-cache-dir --upgrade "cmake>=3.24" --break-system-packages
 COPY /github_clones/kiss-icp /ros2_ws_github/src/kiss-icp
 WORKDIR /ros2_ws_github
 # Explicitly use bash, not sh, to source and build the workspace
-RUN bash -c "source /opt/ros/humble/setup.bash && colcon build --symlink-install"
+RUN bash -c "source /opt/ros/jazzy/setup.bash && colcon build --symlink-install"
 
 # Add pymavlink for debugging and testing
-RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir --resume-retries 5 pymavlink
+RUN pip3 install --no-cache-dir pymavlink --break-system-packages
 # Check with $ python3 -c "import pymavlink; print(pymavlink.__version__)"
 
 # Install Zenoh
 RUN echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
-RUN apt-get update && \
+RUN apt-get update --allow-releaseinfo-change || (sleep 30 && apt-get update --allow-releaseinfo-change) && \
     apt-get install -y zenoh-bridge-ros2dds \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
@@ -192,9 +191,13 @@ RUN apt-get update && \
 FROM ros2-px4msgs-dds-mavros-yolo-kissicp-zenoh-image AS aircraft-dev-image
 
 # Install PlotJuggler
-RUN apt-get update && \
-    apt-get install -y ros-humble-plotjuggler \
-    ros-humble-plotjuggler-ros \
+RUN apt-get update --allow-releaseinfo-change || (sleep 30 && apt-get update --allow-releaseinfo-change) && \
+    apt-get install -y ros-jazzy-plotjuggler  \
+    ros-jazzy-plotjuggler-ros \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get install -y geographiclib-tools libgeographiclib-dev  \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -203,19 +206,24 @@ COPY simulation/simulation_ws/src/ground_system_msgs /ros2_ws/src/ground_system_
 COPY aircraft/aircraft_ws/src /ros2_ws/src
 WORKDIR /ros2_ws
 RUN rosdep update
-RUN rosdep install --from-paths src/ --ignore-src --rosdistro humble -y --skip-keys "px4_msgs"
+RUN rosdep install --from-paths src/ --ignore-src --rosdistro jazzy -y --skip-keys "px4_msgs"
+
+#temp hack since it seens libgeographic is now libgeographiclib 
+RUN ln -s /usr/lib/x86_64-linux-gnu/libGeographicLib.so /usr/lib/x86_64-linux-gnu/libGeographic.so
+RUN  ldconfig
+
 # Explicitly use bash, not sh, to source and build the workspace
-RUN bash -c "source /opt/ros/humble/setup.bash && source /ros2_ws_github/install/setup.bash && colcon build --symlink-install"
+RUN bash -c "source /opt/ros/jazzy/setup.bash && source /ros2_ws_github/install/setup.bash && colcon build --symlink-install"
 
 # Copy resources and configuration files from this repository
 COPY aircraft/aircraft_resources/ /aircraft_resources
 COPY aircraft/aircraft_resources/patches/kiss_icp.rviz /ros2_ws_github/src/kiss-icp/ros/rviz/kiss_icp.rviz
-COPY aircraft/aircraft_resources/patches/apm_pluginlists.yaml /opt/ros/humble/share/mavros/launch/apm_pluginlists.yaml
+COPY aircraft/aircraft_resources/patches/apm_pluginlists.yaml /opt/ros/jazzy/share/mavros/launch/apm_pluginlists.yaml
 
 # Source the workspaces
 RUN echo "source /ros2_ws_github/install/setup.bash" >> /root/.bashrc
 RUN echo "source /ros2_ws/install/setup.bash" >> /root/.bashrc
-# If needed (but already in .bashrc) $ source /opt/ros/humble/setup.bash && source /ros2_ws_github/install/setup.bash && source /ros2_ws/install/setup.bash
+# If needed (but already in .bashrc) $ source /opt/ros/jazzy/setup.bash && source /ros2_ws_github/install/setup.bash && source /ros2_ws/install/setup.bash
 
 # Final config
 WORKDIR /

--- a/scripts/docker/Dockerfile.simulation
+++ b/scripts/docker/Dockerfile.simulation
@@ -1,13 +1,13 @@
 ################################################################################
 # Stage 1 - 8GB ################################################################
 ################################################################################
-FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04 AS ros2-image
+FROM nvcr.io/nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04 AS ros2-image
 
 # Tell apt (and other Debian tools) not to prompt for user input during package installs
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Update the package list and install basic dependencies
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
         wget gosu htop vim ruby tmux net-tools iproute2 iputils-ping \
         python3-pip python3-venv \
@@ -16,9 +16,9 @@ RUN apt update \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Install ROS2 Humble
-# Based on https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debs.html
-RUN apt update \
+# Install ROS2 Jazzy
+# Based on https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
         locales \
     && apt clean \
@@ -26,7 +26,7 @@ RUN apt update \
 RUN locale-gen en_US en_US.UTF-8
 RUN update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
 ENV LANG=en_US.UTF-8
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
         software-properties-common curl \
     && apt clean \
@@ -34,14 +34,14 @@ RUN apt update \
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu \
     $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
-        ros-humble-desktop ros-dev-tools \
-        ros-humble-bondcpp ros-humble-ament-cmake-clang-format \
-        ros-humble-vision-msgs \
+        ros-jazzy-desktop ros-dev-tools \
+        ros-jazzy-bondcpp ros-jazzy-ament-cmake-clang-format \
+        ros-jazzy-vision-msgs \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
-RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc
+RUN echo "source /opt/ros/jazzy/setup.bash" >> /root/.bashrc
 RUN rosdep init
 
 ################################################################################
@@ -51,16 +51,16 @@ FROM ros2-image AS ros2-gz-qgc-image
 
 # Gazebo Harmonic
 # Based on https://gazebosim.org/docs/harmonic/install_ubuntu/
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
         lsb-release gnupg \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 RUN curl https://packages.osrfoundation.org/gazebo.gpg --output /usr/share/keyrings/pkgs-osrf-archive-keyring.gpg
 RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/pkgs-osrf-archive-keyring.gpg] http://packages.osrfoundation.org/gazebo/ubuntu-stable $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/gazebo-stable.list > /dev/null
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
-        gz-harmonic ros-humble-ros-gzharmonic \
+        gz-harmonic ros-jazzy-ros-gz \
         libgz-transport13-* python3-gz-transport13 python3-gz-msgs10 \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
@@ -72,7 +72,7 @@ WORKDIR /
 RUN useradd -m -s /bin/bash qgcuser
 RUN usermod -aG dialout qgcuser
 # RUN apt-get remove modemmanager -y
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
         gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl \
         libfuse2 \
@@ -118,14 +118,13 @@ RUN chown -R root:root /git/ardupilot
 # Based on https://ardupilot.org/dev/docs/sitl-with-gazebo.html
 COPY /github_clones/ardupilot_gazebo /git/ardupilot_gazebo
 WORKDIR /git/ardupilot_gazebo
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
         rapidjson-dev \
         libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
-RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir --resume-retries 5 "numpy<2" mavproxy
+RUN pip3 install --no-cache-dir "numpy<2" mavproxy --break-system-packages
 ENV GZ_VERSION=harmonic
 RUN mkdir build && cd build && \
     cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo && \
@@ -134,7 +133,7 @@ RUN mkdir build && cd build && \
 ################################################################################
 # Temporary stage to filter airframes ##########################################
 ################################################################################
-FROM ubuntu:22.04 AS airframe_filter_stage
+FROM ubuntu:24.04 AS airframe_filter_stage
 COPY simulation/simulation_resources/aircraft_models/ /temp_folder
 RUN mkdir /airframes
 RUN find /temp_folder -type f -regex '.*/[0-9]+_.*' -exec cp {} /airframes/ \;
@@ -171,7 +170,7 @@ RUN make px4_sitl
 FROM ros2-gz-qgc-px4custom-ardupilot-image AS ros2-gz-qgc-px4custom-ardupilot-gst-pymavlink-zenoh-image
 
 # Add GStreamer packages to stream the cameras to the aircraft containers
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
         gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-libav \
         python3-gi gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 \
@@ -179,13 +178,12 @@ RUN apt update \
     && rm -rf /var/lib/apt/lists/*
 
 # Add pymavlink to emulate the ground system using telemetry data
-RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir --resume-retries 5 pymavlink
+RUN pip3 install --no-cache-dir pymavlink --break-system-packages
 # Check with $ python3 -c "import pymavlink; print(pymavlink.__version__)"
 
 # Install Zenoh
 RUN echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
-RUN apt-get update && \
+RUN apt-get update --allow-releaseinfo-change || (sleep 30 && apt-get update --allow-releaseinfo-change) && \
     apt-get install -y zenoh-bridge-ros2dds \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
@@ -196,14 +194,14 @@ RUN apt-get update && \
 FROM ros2-gz-qgc-px4custom-ardupilot-gst-pymavlink-zenoh-image AS simulation-dev-image
 
 # Install wmctrl and xrandr to resize Gazebo and QGC GUIs
-RUN apt update \
+RUN apt update --allow-releaseinfo-change || (sleep 30 && apt update --allow-releaseinfo-change) \
     && apt install -y --no-install-recommends \
         wmctrl x11-xserver-utils \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
 # Install https://github.com/PX4/flight_review
-RUN apt-get update && \
+RUN apt-get update --allow-releaseinfo-change || (sleep 30 && apt-get update --allow-releaseinfo-change) && \
     apt-get install -y sqlite3 libfftw3-bin libfftw3-dev \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
@@ -211,23 +209,23 @@ COPY /github_clones/flight_review /git/flight_review
 WORKDIR /git/flight_review/app
 RUN python3 -m venv /px4rf-env
 RUN /px4rf-env/bin/pip3 install --no-cache-dir --upgrade pip && \
-    /px4rf-env/bin/pip3 install --no-cache-dir --resume-retries 5 -r requirements.txt
+    /px4rf-env/bin/pip3 install --no-cache-dir -r requirements.txt
 
 # Build the ROS 2 workspace for external packages
 RUN mkdir -p /ros2_ws_github/src
 WORKDIR /ros2_ws_github
 RUN rosdep update
-RUN rosdep install --from-paths src/ --ignore-src --rosdistro humble -y
+RUN rosdep install --from-paths src/ --ignore-src --rosdistro jazzy -y
 # Explicitly use bash, not sh, to source and build the workspace
-RUN bash -c "source /opt/ros/humble/setup.bash && colcon build --symlink-install"
+RUN bash -c "source /opt/ros/jazzy/setup.bash && colcon build --symlink-install"
 
 # Build the ROS 2 workspace
 COPY simulation/simulation_ws/src /ros2_ws/src
 WORKDIR /ros2_ws
 RUN rosdep update
-RUN rosdep install --from-paths src/ --ignore-src --rosdistro humble -y
+RUN rosdep install --from-paths src/ --ignore-src --rosdistro jazzy -y
 # Explicitly use bash, not sh, to source and build the workspace
-RUN bash -c "source /opt/ros/humble/setup.bash && source /ros2_ws_github/install/setup.bash && colcon build --symlink-install"
+RUN bash -c "source /opt/ros/jazzy/setup.bash && source /ros2_ws_github/install/setup.bash && colcon build --symlink-install"
 
 # Copy resources and configuration files from this repository
 COPY simulation/simulation_resources/ /simulation_resources
@@ -238,7 +236,7 @@ RUN chmod +x /simulation_resources/simulation_worlds/_create_ardupilot_world.sh
 # Source the workspaces
 RUN echo "source /ros2_ws_github/install/setup.bash" >> /root/.bashrc
 RUN echo "source /ros2_ws/install/setup.bash" >> /root/.bashrc
-# If needed (but already in .bashrc) $ source /opt/ros/humble/setup.bash && source /ros2_ws_github/install/setup.bash && source /ros2_ws/install/setup.bash
+# If needed (but already in .bashrc) $ source /opt/ros/jazzy/setup.bash && source /ros2_ws_github/install/setup.bash && source /ros2_ws/install/setup.bash
 
 # Final config
 WORKDIR /


### PR DESCRIPTION
support ubuntu 24 for the images cause on some nvidia setups dont work with ubuntu 22.


Basically if you update the NVIDIA Container Runtime to 1.18 or later on Ubuntu 24, you can no longer use VMs on Ubuntu 22. So if you use a new Ubuntu, it's not possible to run the project. This is a fix for whoever needs it