### PR TITLE
String Format in ROS2 Logger

### DIFF
--- a/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
@@ -279,13 +279,13 @@ void ArdupilotInterface::set_speed_callback(const std::shared_ptr<autopilot_inte
     std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
     if (((mav_type_ == 2) && aircraft_fsm_state_ != ArdupilotInterfaceState::MC_HOVER) || ((mav_type_ == 1) && aircraft_fsm_state_ != ArdupilotInterfaceState::FW_CRUISE)) {
         response->message = "Set speed rejected, ArdupilotInterface is not in hover/cruise state";
-        RCLCPP_ERROR(this->get_logger(), response->message.c_str());
+        RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
         response->success = false;
         return;
     }
     if (active_srv_or_act_flag_.exchange(true)) {
         response->message = "Another service/action is active";
-        RCLCPP_ERROR(this->get_logger(), response->message.c_str());
+        RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
         response->success = false;
         return;
     }
@@ -313,14 +313,14 @@ void ArdupilotInterface::set_reposition_callback(const std::shared_ptr<autopilot
         std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
         if ((mav_type_ == 1) || ((mav_type_ == 2) && !(aircraft_fsm_state_ == ArdupilotInterfaceState::MC_HOVER || aircraft_fsm_state_ == ArdupilotInterfaceState::MC_ORBIT))) {
             response->message = "Set reposition rejected, ArdupilotInterface is not in a quad hover/orbit state (for VTOLs, use /orbit_action)";
-            RCLCPP_ERROR(this->get_logger(), response->message.c_str());
+            RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
             response->success = false;
             return;
         }
     }
     if (active_srv_or_act_flag_.exchange(true)) {
         response->message = "Another service/action is active";
-        RCLCPP_ERROR(this->get_logger(), response->message.c_str());
+        RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
         response->success = false;
         return;
     }

--- a/aircraft/aircraft_ws/src/autopilot_interface/src/px4_interface.cpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/px4_interface.cpp
@@ -283,13 +283,13 @@ void PX4Interface::set_speed_callback(const std::shared_ptr<autopilot_interface_
     std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
     if ((!is_vtol_ && aircraft_fsm_state_ != PX4InterfaceState::MC_HOVER) || (is_vtol_ && aircraft_fsm_state_ != PX4InterfaceState::FW_CRUISE)) {
         response->message = "Set speed rejected, PX4Interface is not in hover/cruise state";
-        RCLCPP_ERROR(this->get_logger(), response->message.c_str());
+        RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
         response->success = false;
         return;
     }
     if (active_srv_or_act_flag_.exchange(true)) {
         response->message = "Another service/action is active";
-        RCLCPP_ERROR(this->get_logger(), response->message.c_str());
+        RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
         response->success = false;
         return;
     }
@@ -308,13 +308,13 @@ void PX4Interface::set_reposition_callback(const std::shared_ptr<autopilot_inter
     std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
     if ((is_vtol_) || (!is_vtol_ && !(aircraft_fsm_state_ == PX4InterfaceState::MC_HOVER || aircraft_fsm_state_ == PX4InterfaceState::MC_ORBIT))) {
         response->message = "Set reposition rejected, PX4Interface is not in a quad hover/orbit state (for VTOLs, use /orbit_action)";
-        RCLCPP_ERROR(this->get_logger(), response->message.c_str());
+        RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
         response->success = false;
         return;
     }
     if (active_srv_or_act_flag_.exchange(true)) {
         response->message = "Another service/action is active";
-        RCLCPP_ERROR(this->get_logger(), response->message.c_str());
+        RCLCPP_ERROR(this->get_logger(), "%s", response->message.c_str());
         response->success = false;
         return;
     }


### PR DESCRIPTION
`RCLCPP_ERROR` (like `printf`) expects a format string as its second argument. If `response->message` ever accidentally contains characters like `%s` or `%d`, the logger will try to interpret them, leading to garbage output or a crash.