### PR TITLE
DeepStream base image for Orin

### DIFF
--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -175,6 +175,8 @@ RUN mkdir build && cd build && \
     ldconfig
 COPY /github_clones/livox_ros_driver2 /aas/github_ws/src/livox_ros_driver2
 WORKDIR /aas/github_ws/
+# Fix broken HPC-X MPI include path that crashes PCL/VTK compilation in Jetson containers
+RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include
 # Based on https://github.com/Livox-SDK/livox_ros_driver2/blob/master/README.md
 # https://github.com/Livox-SDK/livox_ros_driver2/blob/master/build.sh
 RUN cp -f src/livox_ros_driver2/package_ROS2.xml src/livox_ros_driver2/package.xml \

--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -175,12 +175,7 @@ RUN mkdir build && cd build && \
     ldconfig
 COPY /github_clones/livox_ros_driver2 /aas/github_ws/src/livox_ros_driver2
 WORKDIR /aas/github_ws/
-# Fix broken HPC-X MPI include path that crashes PCL/VTK compilation in Jetson containers
-RUN echo "==========================================================" && \
-    echo "         MISSING HPC-X MPI DIRECTORIES LIST               " && \
-    echo "==========================================================" && \
-    mpicc --showme:compile | tr ' ' '\n' | grep '^-I' | cut -c 3- && \
-    echo "=========================================================="
+# Fix broken HPC-X MPI include paths that crash compilation in Jetson containers
 RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi/opal/mca/hwloc/hwloc201/hwloc/include
 RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent/include
 # Based on https://github.com/Livox-SDK/livox_ros_driver2/blob/master/README.md
@@ -209,10 +204,15 @@ RUN pip3 install --no-cache-dir --upgrade pip \
 
 # Install Zenoh
 RUN echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
+# Download, unpack, delete postinst script (crashing on DeepStream base image), and force configuration
 RUN apt-get update && \
-    apt-get install -y zenoh-bridge-ros2dds \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
+    apt-get download zenoh-bridge-ros2dds && \
+    dpkg --unpack zenoh-bridge-ros2dds*.deb && \
+    rm -f /var/lib/dpkg/info/zenoh-bridge-ros2dds.postinst && \
+    dpkg --configure zenoh-bridge-ros2dds && \
+    apt-get install -yf && \
+    apt clean && \
+    rm -rf /var/lib/apt/lists/* zenoh-bridge-ros2dds*.deb
 
 ################################################################################
 # Stage 7 - 17+GB ##############################################################

--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -176,8 +176,13 @@ RUN mkdir build && cd build && \
 COPY /github_clones/livox_ros_driver2 /aas/github_ws/src/livox_ros_driver2
 WORKDIR /aas/github_ws/
 # Fix broken HPC-X MPI include path that crashes PCL/VTK compilation in Jetson containers
+RUN echo "==========================================================" && \
+    echo "         MISSING HPC-X MPI DIRECTORIES LIST               " && \
+    echo "==========================================================" && \
+    mpicc --showme:compile | tr ' ' '\n' | grep '^-I' | cut -c 3- && \
+    echo "=========================================================="
 RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi/opal/mca/hwloc/hwloc201/hwloc/include
-RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent
+RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent/include
 # Based on https://github.com/Livox-SDK/livox_ros_driver2/blob/master/README.md
 # https://github.com/Livox-SDK/livox_ros_driver2/blob/master/build.sh
 RUN cp -f src/livox_ros_driver2/package_ROS2.xml src/livox_ros_driver2/package.xml \

--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -176,7 +176,7 @@ RUN mkdir build && cd build && \
 COPY /github_clones/livox_ros_driver2 /aas/github_ws/src/livox_ros_driver2
 WORKDIR /aas/github_ws/
 # Fix broken HPC-X MPI include path that crashes PCL/VTK compilation in Jetson containers
-RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi
+RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi/opal/mca/hwloc/hwloc201/hwloc/include
 # Based on https://github.com/Livox-SDK/livox_ros_driver2/blob/master/README.md
 # https://github.com/Livox-SDK/livox_ros_driver2/blob/master/build.sh
 RUN cp -f src/livox_ros_driver2/package_ROS2.xml src/livox_ros_driver2/package.xml \

--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -176,7 +176,7 @@ RUN mkdir build && cd build && \
 COPY /github_clones/livox_ros_driver2 /aas/github_ws/src/livox_ros_driver2
 WORKDIR /aas/github_ws/
 # Fix broken HPC-X MPI include path that crashes PCL/VTK compilation in Jetson containers
-RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include
+RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi
 # Based on https://github.com/Livox-SDK/livox_ros_driver2/blob/master/README.md
 # https://github.com/Livox-SDK/livox_ros_driver2/blob/master/build.sh
 RUN cp -f src/livox_ros_driver2/package_ROS2.xml src/livox_ros_driver2/package.xml \

--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -51,6 +51,10 @@ RUN rosdep init
 ################################################################################
 FROM ros2-image AS ros2-px4msgs-image
 
+# WIP: pin setuptools in deepstreamer image not to conflict with humble
+RUN pip3 install --no-cache-dir --upgrade pip \
+    && pip3 install --no-cache-dir --resume-retries 5 setuptools==58.2.0
+
 # Build PX4 messages
 COPY /github_clones/px4_msgs /aas/github_ws/src/px4_msgs
 WORKDIR /aas/github_ws

--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -1,5 +1,5 @@
 FROM nvcr.io/nvidia/cuda:12.9.1-cudnn-runtime-ubuntu22.04 AS base_amd64
-FROM nvcr.io/nvidia/l4t-jetpack:r36.4.0 AS base_arm64
+FROM nvcr.io/nvidia/deepstream:7.1-triton-multiarch AS base_arm64
 ################################################################################
 # Stage 1 - 8GB ################################################################
 ################################################################################

--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -177,6 +177,7 @@ COPY /github_clones/livox_ros_driver2 /aas/github_ws/src/livox_ros_driver2
 WORKDIR /aas/github_ws/
 # Fix broken HPC-X MPI include path that crashes PCL/VTK compilation in Jetson containers
 RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi/opal/mca/hwloc/hwloc201/hwloc/include
+RUN mkdir -p /opt/hpcx/ompi/lib/aarch64-linux-gnu/openmpi/include/openmpi/opal/mca/event/libevent2022/libevent
 # Based on https://github.com/Livox-SDK/livox_ros_driver2/blob/master/README.md
 # https://github.com/Livox-SDK/livox_ros_driver2/blob/master/build.sh
 RUN cp -f src/livox_ros_driver2/package_ROS2.xml src/livox_ros_driver2/package.xml \


### PR DESCRIPTION
TODOs
- [x] compiling on Orin
- [ ] tested on Orin
- [ ] compiling in arm64 GitHub action
- [ ] compiling on amd64 laptop/GitHub action
- [ ] tested on amd64 laptop

Known issues
- failing to `import cv2` on Orin