### PR TITLE
Improve NumPy Management

### DIFF
--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -93,11 +93,16 @@ RUN /opt/ros/humble/lib/mavros/install_geographiclib_datasets.sh
 ################################################################################
 FROM ros2-px4msgs-dds-mavros-image AS ros2-px4msgs-dds-mavros-yolo-image
 
+# TODO: improve numpy management
+RUN echo "numpy<2.0.0" > /etc/pip_constraints.txt
+ENV PIP_CONSTRAINT=/etc/pip_constraints.txt
+ENV CPATH=/usr/local/lib/python3.10/dist-packages/numpy/core/include
+
 # Install YOLO and ONNX in virtual environment /yolo-env/
 # See https://github.com/ultralytics/ultralytics/blob/main/README.md and https://onnxruntime.ai/getting-started
 RUN python3 -m venv /yolo-env
 RUN /yolo-env/bin/pip3 install --no-cache-dir --upgrade pip && \
-    /yolo-env/bin/pip3 install --no-cache-dir --resume-retries 5 "ultralytics==8.4.37" onnx
+    /yolo-env/bin/pip3 install --no-cache-dir --resume-retries 5 ultralytics onnx
 # Check YOLO with $ /yolo-env/bin/python3 -c "import ultralytics; print(ultralytics.__version__)"
 
 # Test ONNX export (WARNING: removing this step from this stage can break px4_msgs build in later stages)

--- a/scripts/docker/Dockerfile.aircraft
+++ b/scripts/docker/Dockerfile.aircraft
@@ -93,24 +93,13 @@ RUN /opt/ros/humble/lib/mavros/install_geographiclib_datasets.sh
 ################################################################################
 FROM ros2-px4msgs-dds-mavros-image AS ros2-px4msgs-dds-mavros-yolo-image
 
-# TODO: improve numpy management
+# In Ubuntu 22, package python3-numpy is on version 1.21.5, check with $ dpkg -l | grep python3-numpy
+# ONNX will pip install >=1.21.6 but we constraint it to <2.0.0 for system Python's OpenCV ABI compatibility
+# Check with $ python3 -c "import numpy; print(numpy.__version__)"
 RUN echo "numpy<2.0.0" > /etc/pip_constraints.txt
 ENV PIP_CONSTRAINT=/etc/pip_constraints.txt
+# Point the GCC compiler to the new pip NumPy headers (instead of the apt ones) to prevent ROS2 colcon from crashing
 ENV CPATH=/usr/local/lib/python3.10/dist-packages/numpy/core/include
-
-# Install YOLO and ONNX in virtual environment /yolo-env/
-# See https://github.com/ultralytics/ultralytics/blob/main/README.md and https://onnxruntime.ai/getting-started
-RUN python3 -m venv /yolo-env
-RUN /yolo-env/bin/pip3 install --no-cache-dir --upgrade pip && \
-    /yolo-env/bin/pip3 install --no-cache-dir --resume-retries 5 ultralytics onnx
-# Check YOLO with $ /yolo-env/bin/python3 -c "import ultralytics; print(ultralytics.__version__)"
-
-# Test ONNX export (WARNING: removing this step from this stage can break px4_msgs build in later stages)
-WORKDIR /aas/yolo
-RUN /yolo-env/bin/python3 -c "from ultralytics import YOLO; YOLO('yolov8n.pt').export(format='onnx', opset=12)" && \
-    mv yolov8n.onnx unused.onnx
-# Download a sample video for testing
-RUN wget https://github.com/intel-iot-devkit/sample-videos/raw/master/person-bicycle-car-detection.mp4 -O /sample.mp4
 
 # Add GStreamer, Python OpenCV packages
 RUN apt update \
@@ -120,9 +109,13 @@ RUN apt update \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
-# NOTE: we want system Python's OpenCV to have GStreamer support
-RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir --resume-retries 5 "numpy<2"
+# Install YOLO and ONNX in virtual environment /yolo-env/
+# See https://github.com/ultralytics/ultralytics/blob/main/README.md and https://onnxruntime.ai/getting-started
+RUN python3 -m venv /yolo-env
+RUN /yolo-env/bin/pip3 install --no-cache-dir --upgrade pip && \
+    /yolo-env/bin/pip3 install --no-cache-dir --resume-retries 5 ultralytics onnx
+# Check YOLO with $ /yolo-env/bin/python3 -c "import ultralytics; print(ultralytics.__version__)"
+# NOTE: the venv avoids shadowing the system Python's OpenCV (with GStreamer support) with a newer one without GStreamer support
 # Check with $ python3 -c "import cv2; print(cv2.getBuildInformation())"
 # Versus $ /yolo-env/bin/python3 -c "import cv2; print(cv2.getBuildInformation())"
 
@@ -217,11 +210,6 @@ WORKDIR /aas/github_ws
 # Explicitly use bash, not sh, to source and build the workspace
 RUN bash -c "source /opt/ros/humble/setup.bash && colcon build --symlink-install --packages-skip livox_ros_driver2 --cmake-args -DCMAKE_BUILD_TYPE=Release"
 
-# Add pymavlink for debugging and testing
-RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir --resume-retries 5 pymavlink pyserial
-# Check with $ python3 -c "import pymavlink; print(pymavlink.__version__)"
-
 # Install Zenoh
 RUN echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
 RUN apt-get update && \
@@ -232,7 +220,17 @@ RUN apt-get update && \
 ################################################################################
 # Stage 7 - 17+GB ##############################################################
 ################################################################################
-FROM ros2-px4msgs-dds-mavros-yolo-kissicp-zenoh-image AS aircraft-dev-image
+FROM ros2-px4msgs-dds-mavros-yolo-kissicp-zenoh-image AS ros2-px4msgs-dds-mavros-yolo-kissicp-zenoh-analysis-models-image
+
+# Add pymavlink and PlotJuggler for debugging, testing, and analysis
+RUN pip3 install --no-cache-dir --upgrade pip \
+    && pip3 install --no-cache-dir --resume-retries 5 pymavlink pyserial
+# Check with $ python3 -c "import pymavlink; print(pymavlink.__version__)"
+RUN apt-get update && \
+    apt-get install -y ros-humble-plotjuggler \
+    ros-humble-plotjuggler-ros \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Save the YOLO model weights (ONNX, Opset 12) and class names
 WORKDIR /aas/yolo
@@ -245,12 +243,10 @@ RUN /yolo-env/bin/python3 -c "from ultralytics import YOLO; YOLO('yolo26n.pt').e
     /yolo-env/bin/python3 -c "import json; from ultralytics import YOLO; print(json.dumps(YOLO('yolo26n.pt').names))" | grep '{' > coco.json && \
     rm yolo26n.pt
 
-# Install PlotJuggler
-RUN apt-get update && \
-    apt-get install -y ros-humble-plotjuggler \
-    ros-humble-plotjuggler-ros \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
+################################################################################
+# Stage 8 - 17+GB ##############################################################
+################################################################################
+FROM ros2-px4msgs-dds-mavros-yolo-kissicp-zenoh-analysis-models-image AS aircraft-dev-image
 
 # Build the ROS 2 workspace (NOTE: also includes ground_system_msgs from the ground_ws)
 COPY ground/ground_ws/src/ground_system_msgs /aas/aircraft_ws/src/ground_system_msgs

--- a/scripts/docker/Dockerfile.ground
+++ b/scripts/docker/Dockerfile.ground
@@ -68,6 +68,13 @@ RUN wget https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-x86_64.AppI
     rm /QGroundControl-x86_64.AppImage
 # Run with $ gosu qgcuser /squashfs-root/AppRun
 
+# Install wmctrl and xrandr to resize QGC window
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        wmctrl x11-xserver-utils \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Zenoh
 RUN echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
 RUN apt-get update && \
@@ -78,7 +85,7 @@ RUN apt-get update && \
 ################################################################################
 # Stage 3 - 8+GB ###############################################################
 ################################################################################
-FROM ros2-qgc-zenoh-image AS ros2-qgc-zenoh-gst-pymavlink-image
+FROM ros2-qgc-zenoh-image AS ros2-qgc-zenoh-gst-mavlink-image
 
 # Add GStreamer packages to stream the cameras to the aircraft containers
 RUN apt update \
@@ -93,11 +100,6 @@ RUN pip3 install --no-cache-dir --upgrade pip \
     && pip3 install --no-cache-dir --resume-retries 5 pymavlink pyserial mavproxy future
 # Check with $ python3 -c "import pymavlink; print(pymavlink.__version__)"
 
-################################################################################
-# Stage 4 - 8+GB ###############################################################
-################################################################################
-FROM ros2-qgc-zenoh-gst-pymavlink-image AS ground-dev-image
-
 # Install mavlink-router
 RUN apt update \
     && apt install -y --no-install-recommends \
@@ -111,15 +113,13 @@ RUN meson setup build . --buildtype=release \
     && ninja -C build install
 # Check with $ mavlink-routerd --version
 
-# Install wmctrl and xrandr to resize QGC window
-RUN apt update \
-    && apt install -y --no-install-recommends \
-        wmctrl x11-xserver-utils \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
-
 # Add MAVLink 2 C library
 COPY /github_clones/c_library_v2 /usr/local/include/mavlink/
+
+################################################################################
+# Stage 4 - 8+GB ###############################################################
+################################################################################
+FROM ros2-qgc-zenoh-gst-mavlink-image AS ground-dev-image
 
 # Build the ROS 2 workspace
 COPY ground/ground_ws/src /aas/ground_ws/src

--- a/scripts/docker/Dockerfile.simulation
+++ b/scripts/docker/Dockerfile.simulation
@@ -68,6 +68,13 @@ RUN wget https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl-x86_64.AppI
     rm /QGroundControl-x86_64.AppImage
 # Run with $ gosu qgcuser /squashfs-root/AppRun
 
+# Install wmctrl and xrandr to resize Gazebo/QGC window
+RUN apt update \
+    && apt install -y --no-install-recommends \
+        wmctrl x11-xserver-utils \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+
 # Install Zenoh
 RUN echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
 RUN apt-get update && \
@@ -185,7 +192,7 @@ RUN make px4_sitl
 ################################################################################
 # Stage 7 - 20GB ###############################################################
 ################################################################################
-FROM ros2-qgc-zenoh-gz-px4custom-ardupilot-image AS ros2-qgc-zenoh-gz-px4custom-ardupilot-gst-pymavlink-image
+FROM ros2-qgc-zenoh-gz-px4custom-ardupilot-image AS ros2-qgc-zenoh-gz-px4custom-ardupilot-gst-logs-zmq-image
 
 # Add GStreamer packages to stream the cameras to the aircraft containers
 RUN apt update \
@@ -196,24 +203,12 @@ RUN apt update \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Add pymavlink to emulate the ground system using telemetry data
+# Add pymavlink and mavproxy to quickly inspect MAVLink streams
 RUN pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir --resume-retries 5 pymavlink pyserial
+    && pip3 install --no-cache-dir --resume-retries 5 pymavlink pyserial mavproxy future
 # Check with $ python3 -c "import pymavlink; print(pymavlink.__version__)"
 
-################################################################################
-# Stage 8 - 21+GB ##############################################################
-################################################################################
-FROM ros2-qgc-zenoh-gz-px4custom-ardupilot-gst-pymavlink-image AS simulation-dev-image
-
-# Install wmctrl and xrandr to resize Gazebo window
-RUN apt update \
-    && apt install -y --no-install-recommends \
-        wmctrl x11-xserver-utils \
-    && apt clean \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install https://github.com/PX4/flight_review
+# Install https://github.com/PX4/flight_review to inspect PX4 SITL logs
 RUN apt-get update && \
     apt-get install -y sqlite3 libfftw3-bin libfftw3-dev \
     && apt clean \
@@ -231,6 +226,11 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 RUN pip3 install --no-cache-dir --upgrade pip \
     && pip3 install --no-cache-dir --resume-retries 5 pyzmq
+
+################################################################################
+# Stage 8 - 21+GB ##############################################################
+################################################################################
+FROM ros2-qgc-zenoh-gz-px4custom-ardupilot-gst-logs-zmq-image AS simulation-dev-image
 
 # Build the ROS 2 workspace
 COPY simulation/simulation_ws/src /aas/simulation_ws/src


### PR DESCRIPTION
Let `numpy` be updated up to `<2.0.0` without breaking OpenCV ABI nor `colcon`