### PR TITLE
Simple 3D Gimbal

### DIFF
--- a/simulation/simulation_resources/aircraft_models/gimbal/model.config
+++ b/simulation/simulation_resources/aircraft_models/gimbal/model.config
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<model>
+  <name>gimbal</name>
+  <version>1.0</version>
+  <sdf version="1.9">model.sdf</sdf>
+  <author>
+    <name>Stefano Colli</name>
+    <email>stefano@auterion.com</email>
+  </author>
+  <description>Gimbal with camera model</description>
+</model>

--- a/simulation/simulation_resources/aircraft_models/gimbal/model.sdf
+++ b/simulation/simulation_resources/aircraft_models/gimbal/model.sdf
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sdf version='1.9'>
+  <model name='gimbal'>
+    <self_collide>false</self_collide>
+    <static>false</static>
+
+    <!-- Gimbal mount point -->
+    <link name="gimbal3d_mount_link">
+      <inertial>
+        <pose>-0.02552 0 -0.08136 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <visual name="gimbal3d_mount_visual">
+        <geometry>
+          <box>
+            <size>0.075 0.075 0.025</size> 
+          </box>
+        </geometry>
+        <material>
+          <ambient>1.0 0.0 0.0 1.0</ambient>
+          <diffuse>1.0 0.0 0.0 1.0</diffuse>
+        </material>
+      </visual>
+    </link>
+
+    <!-- Gimbal vertical arm -->
+    <link name="gimbal3d_vertical_arm_link">
+      <inertial>
+        <pose>0 0 -0.1283 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <visual name='gimbal3d_vertical_arm_visual'>
+        <geometry>
+          <box>
+            <size>0.05 0.1 0.05</size> 
+          </box>
+        </geometry>
+        <material>
+          <ambient>0.0 1.0 0.0 1.0</ambient>
+          <diffuse>0.0 1.0 0.0 1.0</diffuse>
+        </material>
+      </visual>
+    </link>
+
+    <!-- Yaw joint -->
+    <joint name='gimbal3d_vertical_arm_joint' type='revolute'>
+      <child>gimbal3d_vertical_arm_link</child>
+      <parent>gimbal3d_mount_link</parent>
+      <pose>-0.02552 0 0 0 0 0</pose>
+      <axis>
+        <xyz>0 0 -1</xyz>
+        <limit>
+          <lower>-1e+16</lower>
+          <upper>1e+16</upper>
+          <effort>100</effort>
+          <velocity>-1</velocity>
+        </limit>
+        <dynamics>
+          <damping>0.1</damping>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <limit>
+            <cfm>0.1</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
+
+    <!-- Gimbal horizontal arm -->
+    <link name="gimbal3d_horizontal_arm_link">
+      <inertial>
+        <pose>-0.0213 0 -0.162 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <visual name='gimbal3d_horizontal_arm_visual'>
+        <geometry>
+          <box>
+            <size>0.1 0.05 0.05</size> 
+          </box>
+        </geometry>
+        <material>
+          <ambient>0.0 0.0 1.0 1.0</ambient>
+          <diffuse>0.0 0.0 1.0 1.0</diffuse>
+        </material>
+      </visual>
+    </link>
+
+    <!-- Roll joint -->
+    <joint name='gimbal3d_horizontal_arm_joint' type='revolute'>
+      <child>gimbal3d_horizontal_arm_link</child>
+      <parent>gimbal3d_vertical_arm_link</parent>
+      <pose>0 0 -0.1619 0 0 0</pose>
+      <axis>
+        <xyz>-1 0 0</xyz>
+        <limit>
+          <lower>-0.785398</lower>
+          <upper>0.785398</upper>
+          <effort>100</effort>
+          <velocity>-1</velocity>
+        </limit>
+        <dynamics>
+          <damping>0.1</damping>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <limit>
+            <cfm>0.1</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
+
+    <!-- Camera -->
+    <link name="camera_link">
+      <inertial>
+        <pose>-0.0412 0 -0.162 0 0 0</pose>
+        <mass>0.1</mass>
+        <inertia>
+          <ixx>0.001</ixx>
+          <ixy>0</ixy>
+          <ixz>0</ixz>
+          <iyy>0.001</iyy>
+          <iyz>0</iyz>
+          <izz>0.001</izz>
+        </inertia>
+      </inertial>
+      <collision name='gimbal3d_camera_collision'>
+        <pose>-0.0412 0 -0.162 0 0 0</pose>
+        <geometry>
+          <sphere>
+            <radius>0.035</radius>
+          </sphere>
+        </geometry>
+        <surface>
+          <friction>
+            <ode>
+              <mu>1</mu>
+              <mu2>1</mu2>
+            </ode>
+          </friction>
+          <contact>
+            <ode>
+              <kp>1e+8</kp>
+              <kd>1</kd>
+              <max_vel>0.01</max_vel>
+              <min_depth>0.001</min_depth>
+            </ode>
+          </contact>
+        </surface>
+      </collision>
+      <visual name='gimbal3d_camera_visual'>
+        <geometry>
+          <cone>
+            <radius>0.025</radius>
+            <length>0.05</length>
+          </cone>
+        </geometry>
+        <material>
+          <ambient>0 1 0 1.0</ambient>
+          <diffuse>0 1 0 1.0</diffuse>
+        </material>
+      </visual>
+
+      <sensor name="camera_imu" type="imu">
+        <gz_frame_id>camera_link</gz_frame_id>
+        <always_on>1</always_on>
+        <update_rate>250</update_rate>
+        <pose>-0.0412 0 -0.162 0 0 3.14</pose>
+        <imu>
+          <angular_velocity>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.00018665</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.00018665</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.00018665</stddev>
+                <dynamic_bias_stddev>3.8785e-05</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>1000</dynamic_bias_correlation_time>
+              </noise>
+            </z>
+          </angular_velocity>
+          <linear_acceleration>
+            <x>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.00186</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </x>
+            <y>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.00186</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </y>
+            <z>
+              <noise type="gaussian">
+                <mean>0</mean>
+                <stddev>0.00186</stddev>
+                <dynamic_bias_stddev>0.006</dynamic_bias_stddev>
+                <dynamic_bias_correlation_time>300</dynamic_bias_correlation_time>
+              </noise>
+            </z>
+          </linear_acceleration>
+        </imu>
+      </sensor>
+
+      <sensor name="camera" type="camera">
+        <gz_frame_id>camera_link</gz_frame_id>
+        <pose>-0.0412 0 -0.162 0 0 3.14</pose>
+        <camera>
+          <horizontal_fov>2.0</horizontal_fov>
+          <image>
+            <format>R8G8B8</format>
+            <format>R8G8B8</format>
+            <width>1280</width>
+            <height>720</height>
+          </image>
+          <clip>
+            <near>0.05</near>
+            <far>15000</far>
+          </clip>
+        </camera>
+        <always_on>1</always_on>
+        <update_rate>30</update_rate>
+        <visualize>true</visualize>
+      </sensor>
+    </link>
+
+    <!-- Pitch joint -->
+    <joint name='gimbal3d_camera_joint' type='revolute'>
+      <child>camera_link</child>
+      <parent>gimbal3d_horizontal_arm_link</parent>
+      <pose>-0.0412 0 -0.162 0 0 0</pose>
+      <axis>
+        <xyz>0 1 0</xyz>
+        <limit>
+          <lower>-2.35619</lower>
+          <upper>0.7854</upper>
+          <effort>100</effort>
+          <velocity>-1</velocity>
+        </limit>
+        <dynamics>
+          <damping>0.1</damping>
+        </dynamics>
+      </axis>
+      <physics>
+        <ode>
+          <implicit_spring_damper>1</implicit_spring_damper>
+          <limit>
+            <cfm>0.1</cfm>
+            <erp>0.2</erp>
+          </limit>
+        </ode>
+      </physics>
+    </joint>
+
+    <!-- Plugins -->
+    <plugin
+      filename="gz-sim-joint-position-controller-system"
+      name="gz::sim::systems::JointPositionController">
+      <joint_name>gimbal3d_horizontal_arm_joint</joint_name>
+      <sub_topic>command/gimbal_roll</sub_topic>
+      <p_gain>0.8</p_gain>
+      <i_gain>0.035</i_gain>
+      <d_gain>0.02</d_gain>
+      <i_max>0</i_max>
+      <i_min>0</i_min>
+      <cmd_max>0.3</cmd_max>
+      <cmd_min>-0.3</cmd_min>
+    </plugin>
+
+    <plugin
+      filename="gz-sim-joint-position-controller-system"
+      name="gz::sim::systems::JointPositionController">
+      <joint_name>gimbal3d_camera_joint</joint_name>
+      <sub_topic>command/gimbal_pitch</sub_topic>
+      <p_gain>0.8</p_gain>
+      <i_gain>0.01245</i_gain>
+      <d_gain>0.015</d_gain>
+      <i_max>0</i_max>
+      <i_min>0</i_min>
+      <cmd_max>0.3</cmd_max>
+      <cmd_min>-0.3</cmd_min>
+    </plugin>
+
+    <plugin
+      filename="gz-sim-joint-position-controller-system"
+      name="gz::sim::systems::JointPositionController">
+      <joint_name>gimbal3d_vertical_arm_joint</joint_name>
+      <sub_topic>command/gimbal_yaw</sub_topic>
+      <p_gain>0.3</p_gain>
+      <i_gain>0.01245</i_gain>
+      <d_gain>0.015</d_gain>
+      <i_max>0</i_max>
+      <i_min>0</i_min>
+      <cmd_max>0.3</cmd_max>
+      <cmd_min>-0.3</cmd_min>
+    </plugin>
+
+  </model>
+</sdf>

--- a/simulation/simulation_resources/aircraft_models/iris_with_ardupilot/ardupilot-4.6.params
+++ b/simulation/simulation_resources/aircraft_models/iris_with_ardupilot/ardupilot-4.6.params
@@ -2,3 +2,40 @@ ARMING_CHECK 60
 WP_YAW_BEHAVIOR 3
 WPNAV_SPEED 500
 SCHED_LOOP_RATE 250
+
+# Match servo out for motors
+MOT_PWM_MIN      1100
+MOT_PWM_MAX      1900
+
+# Servo gimbal on mount 1 has 3 DOF
+MNT1_TYPE        1
+MNT1_PITCH_MAX   45
+MNT1_PITCH_MIN   -135
+MNT1_ROLL_MAX    30
+MNT1_ROLL_MIN    -30
+MNT1_YAW_MAX     160
+MNT1_YAW_MIN     -160
+
+# Gimbal RC in
+RC6_MAX          1900
+RC6_MIN          1100
+
+# Mount1 Roll
+RC6_OPTION       212
+
+# Mount1 Pitch
+RC7_MAX          1900
+RC7_MIN          1100
+RC7_OPTION       213
+
+# Mount1 Yaw
+RC8_MAX          1900
+RC8_MIN          1100
+RC8_OPTION       214
+
+# Mount1Roll
+SERVO9_FUNCTION  8
+# Mount1Pitch
+SERVO10_FUNCTION 7
+# Mount1Yaw
+SERVO11_FUNCTION 6

--- a/simulation/simulation_resources/aircraft_models/iris_with_ardupilot/model.sdf.erb
+++ b/simulation/simulation_resources/aircraft_models/iris_with_ardupilot/model.sdf.erb
@@ -476,6 +476,7 @@
         </physics>
       </joint>
 
+      <!--
       <include>
         <uri>model://sensor_camera</uri>
         <name>simple_camera</name>
@@ -484,6 +485,15 @@
       <joint name="CameraJoint" type="fixed">
         <parent>base_link</parent>
         <child>simple_camera::mono_cam/base_link</child>
+      </joint>
+      -->
+      <include merge='true'>
+        <uri>model://gimbal</uri>
+        <pose>0 0 0.26 0 0 3.14</pose>
+      </include>
+      <joint name="GimbalAttachJoint" type="fixed">
+        <parent>base_link</parent>
+        <child>gimbal3d_mount_link</child>
       </joint>
 
       <include>

--- a/simulation/simulation_resources/aircraft_models/x500/5140_gz_aas_x500
+++ b/simulation/simulation_resources/aircraft_models/x500/5140_gz_aas_x500
@@ -117,3 +117,16 @@ param set-default MPC_Z_V_AUTO_UP 8.0
 # Increase timeouts/rates for faster-than-real-life simulation
 param set-default COM_RC_LOSS_T 35
 param set-default COM_DL_LOSS_T 300
+
+# Gimbal settings
+param set-default MNT_MODE_IN 4
+param set-default MNT_MODE_OUT 2
+param set-default MNT_RC_IN_MODE 1
+
+param set-default MNT_MAN_ROLL 1
+param set-default MNT_MAN_PITCH 2
+param set-default MNT_MAN_YAW 3
+
+param set-default MNT_RANGE_ROLL 180
+param set-default MNT_RANGE_PITCH 180
+param set-default MNT_RANGE_YAW 720

--- a/simulation/simulation_resources/aircraft_models/x500/model.sdf.erb
+++ b/simulation/simulation_resources/aircraft_models/x500/model.sdf.erb
@@ -662,6 +662,7 @@
       <motorType>velocity</motorType>
     </plugin>
 
+    <!--
     <include>
       <uri>model://sensor_camera</uri>
       <name>simple_camera</name>
@@ -670,6 +671,15 @@
     <joint name="CameraJoint" type="fixed">
       <parent>base_link</parent>
       <child>simple_camera::mono_cam/base_link</child>
+    </joint>
+    -->
+    <include merge='true'>
+      <uri>model://gimbal</uri>
+      <pose>0 0 0.26 0 0 3.14</pose>
+    </include>
+    <joint name="GimbalAttachJoint" type="fixed">
+      <parent>base_link</parent>
+      <child>gimbal3d_mount_link</child>
     </joint>
 
     <include>


### PR DESCRIPTION
References:
- PX4 [params `4019_gz_x500_gimbal`](https://github.com/PX4/PX4-Autopilot/blob/v1.16.1/ROMFS/px4fmu_common/init.d-posix/airframes/4019_gz_x500_gimbal) / [gimbal model](https://github.com/PX4/PX4-gazebo-models/blob/e05f4312d3f28aa621157610584a4870406cb6d3/models/gimbal/model.sdf) / [drone model](https://github.com/PX4/PX4-gazebo-models/blob/e05f4312d3f28aa621157610584a4870406cb6d3/models/x500_gimbal/model.sdf)
- ArduPilot [param file](https://github.com/ArduPilot/ardupilot_gazebo/blob/main/config/gazebo-iris-gimbal.parm) / [gimbal model](https://github.com/ArduPilot/ardupilot_gazebo/blob/main/models/gimbal_small_3d/model.sdf) / [drone model](https://github.com/ArduPilot/ardupilot_gazebo/blob/main/models/iris_with_gimbal/model.sdf)

This PR aims to add a 3D gimbal camera sensor that can be added to any of the vehicles in AAS.
- PX4 SITL resources use "MAVlink gimbal protocol v2" `MNT_MODE_IN 4`
- ArduPilot SITL resources use "Mount type Servo" `MNT1_TYPE  1`
- Both use the `gz-sim-joint-position-controller-system` plugin

For the sake of simplicity, and because AAS targets ROS2-based on-board autonomy (rather than RC/QGC gimbal interfacing through the autopilot), we only bridge gimbal axes control to ROS2.

Writing ROS2 drivers for various commercial gimbals is beyond the scope of this project (although it could be relatively straightforward for MAVlink gimbals connected to PX4 autopilots).