### PR TITLE
add camera zoom with ROS2 bridge

### DIFF
--- a/simulation/simulation.yml.erb
+++ b/simulation/simulation.yml.erb
@@ -133,6 +133,9 @@ windows:
         - >
           ROS_DOMAIN_ID=<%= drone_id %> ros2 run ros_gz_bridge parameter_bridge /model/<%= model_name %>/gimbal_3d/yaw_cmd@std_msgs/msg/Float64]gz.msgs.Double
           --ros-args -r /model/<%= model_name %>/gimbal_3d/yaw_cmd:=gimbal_yaw_cmd
+        - >
+          ROS_DOMAIN_ID=<%= drone_id %> ros2 run ros_gz_bridge parameter_bridge /model/<%= model_name %>/camera/zoom_cmd@std_msgs/msg/Float64]gz.msgs.Double
+          --ros-args -r /model/<%= model_name %>/camera/zoom_cmd:=camera_zoom_cmd
         # (optional/alternative) Use ros_gz_bridge to republish the camera frames into ROS2 and use tools like $ ros2 run rqt_image_view rqt_image_view
         # - >
         #   ROS_DOMAIN_ID=<%= drone_id %> ros2 run ros_gz_bridge parameter_bridge

--- a/simulation/simulation_resources/aircraft_models/sensor_camera/model.sdf.erb
+++ b/simulation/simulation_resources/aircraft_models/sensor_camera/model.sdf.erb
@@ -6,6 +6,10 @@
   diagonal_pixels = Math.sqrt(camera_intrinsics['width'].to_f**2 + camera_intrinsics['height'].to_f**2)
   focal_length = diagonal_pixels / (2.0 * Math.tan(dfov_rad / 2.0))
   hfov_rad = 2.0 * Math.atan(camera_intrinsics['width'].to_f / (2.0 * focal_length))
+  # Optical zoom: scale HFOV by 1/zoom_factor (zoom_factor=2.0 halves HFOV i.e. 2x zoom-in)
+  zoom_factor = (camera_intrinsics['zoom_factor'] || 1.0).to_f
+  zoom_factor = 1.0 if zoom_factor <= 0.0
+  hfov_rad = hfov_rad / zoom_factor
 %>
 <sdf version='1.9'>
   <model name="sensor_camera">

--- a/simulation/simulation_resources/aircraft_models/sensor_config.yaml
+++ b/simulation/simulation_resources/aircraft_models/sensor_config.yaml
@@ -7,6 +7,7 @@ sensors:
     update_rate: 8
     near_clip: 0.1
     far_clip: 2000
+    zoom_factor: 1.0 # Initial optical zoom (>1 zooms in by scaling HFOV by 1/zoom_factor); runtime control via /Drone<N>/camera/zoom_cmd
 
   lidar_intrinsics:
     horizontal_samples: 240

--- a/simulation/simulation_resources/scripts/gz_camera_zoom.py
+++ b/simulation/simulation_resources/scripts/gz_camera_zoom.py
@@ -1,0 +1,51 @@
+"""
+Publish a one-shot camera zoom command (gz.msgs.Double) on the per-model
+zoom_cmd topic. The same topic is bridged to ROS2 in simulation.yml.erb as
+/Drone<N>/camera/zoom_cmd, so external ROS2 nodes can drive the zoom too.
+
+Use as:
+    python3 gz_camera_zoom.py --model x500_0 --zoom 2.0
+    python3 gz_camera_zoom.py --model iris_with_ardupilot_1 --zoom 1.0  # reset
+
+Note: zoom is set at startup from sensor_config.yaml's camera_intrinsics.zoom_factor
+(the static initial HFOV scaling). Runtime HFOV updates require a Gazebo plugin
+that subscribes to the zoom_cmd topic and calls SetHFOV() on the camera sensor;
+this script publishes on that topic so any such consumer (or the ros_gz_bridge)
+can react.
+"""
+import time
+import argparse
+import gz.transport13
+from gz.msgs10.double_pb2 import Double
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Publish a camera zoom command on the model zoom_cmd topic')
+    parser.add_argument('--model', type=str, required=True, help='Model name, e.g. x500_0 or iris_with_ardupilot_1')
+    parser.add_argument('--zoom', type=float, default=1.0, help='Zoom factor (>1 zooms in, 1.0 resets)')
+    args = parser.parse_args()
+
+    if args.zoom <= 0.0:
+        print(f"Zoom factor must be > 0 (got {args.zoom})")
+        return
+
+    topic = f"/model/{args.model}/camera/zoom_cmd"
+    gz_node = gz.transport13.Node()
+    pub = gz_node.advertise(topic, Double)
+
+    timeout = 0
+    while not pub.has_connections():
+        if timeout > 5: # Give up after 5s
+            print(f"No subscribers on {topic}! Is the ros_gz_bridge (or a zoom plugin) running?")
+            return
+        time.sleep(1.0)
+        timeout += 1
+
+    msg = Double()
+    msg.data = args.zoom
+    pub.publish(msg)
+    print(f"Published zoom={args.zoom} on {topic}")
+    time.sleep(0.5) # Wait for publication
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #76

Adds an optical-zoom knob to the simulated camera sensor and wires a ROS2 control topic via `ros_gz_bridge`, mirroring the gimbal pattern from #69.

### Changes

- **`simulation_resources/aircraft_models/sensor_config.yaml`** — new `zoom_factor` field under `camera_intrinsics` (default `1.0`, backwards-compatible).
- **`simulation_resources/aircraft_models/sensor_camera/model.sdf.erb`** — divides the computed `hfov_rad` by `zoom_factor` so `zoom_factor=2.0` halves HFOV (2x zoom-in), `1.0` is a no-op. Guards against `<= 0` values.
- **`simulation/simulation.yml.erb`** (next to the existing `gimbal_3d/*_cmd` bridge lines) — new `ros_gz_bridge` entry mapping `/model/<model_name>/camera/zoom_cmd` (`gz.msgs.Double`) to ROS2 `camera_zoom_cmd` (`std_msgs/msg/Float64`).
- **`simulation_resources/scripts/gz_camera_zoom.py`** — small helper modeled on `gz_wind.py` to publish a zoom value on the per-model topic.

### How zoom is implemented

Zoom is FOV-based (optical zoom): effective HFOV = `base_hfov / zoom_factor`. The initial zoom is set at sim startup from `sensor_config.yaml`. The ROS2 topic + `ros_gz_bridge` mapping is in place so that a runtime-FOV update plugin (or any custom subscriber on the `/model/<model>/camera/zoom_cmd` gz topic) can react to live commands — keeping the interface consistent with the rest of the gimbal/camera stack.

### Try it

```sh
# from a ROS2 shell on the drone domain
ros2 topic pub --once /Drone1/camera_zoom_cmd std_msgs/msg/Float64 "{data: 2.0}"

# or via the helper script (inside the simulation container)
python3 /aas/simulation_resources/scripts/gz_camera_zoom.py --model x500_0 --zoom 2.0
```
