### PR TITLE
Add `ntnu-arl/mimosa`

### DIFF
--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -81,6 +81,8 @@ windows:
         - ros2 launch kiss_matcher_ros run_kiss_matcher_sam.launch.yaml
         <% when 'superodom' %>
         - ros2 launch super_odometry livox_mid360.launch.py
+        <% when 'mimosa' %>
+        - ros2 launch mimosa parrot_launch.py
         <% end %>
         - ros2 run imu_publisher imu_publisher --ros-args -p autopilot:=<%= autopilot %> -p drone_id:=<%= drone_id %> <%= simulated_time ? '-p use_sim_time:=true' : '' %>
   <% end %>

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -83,7 +83,7 @@ windows:
         - ros2 launch super_odometry livox_mid360.launch.py
         <% when 'mimosa' %>
         - ros2 launch mimosa parrot_launch.py
-        - source /aas/temp_dev_ws/install/setup.bash && ros2 run rovio rovio_node
+        - source /aas/temp_dev_ws/install/setup.bash && ros2 launch rovio rovio_node.launch.py
         <% end %>
         - ros2 run imu_publisher imu_publisher --ros-args -p autopilot:=<%= autopilot %> -p drone_id:=<%= drone_id %> <%= simulated_time ? '-p use_sim_time:=true' : '' %>
   <% end %>

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -83,6 +83,7 @@ windows:
         - ros2 launch super_odometry livox_mid360.launch.py
         <% when 'mimosa' %>
         - ros2 launch mimosa parrot_launch.py
+        - source /aas/temp_dev_ws/install/setup.bash && ros2 run rovio rovio_node
         <% end %>
         - ros2 run imu_publisher imu_publisher --ros-args -p autopilot:=<%= autopilot %> -p drone_id:=<%= drone_id %> <%= simulated_time ? '-p use_sim_time:=true' : '' %>
   <% end %>

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -83,7 +83,7 @@ windows:
         - ros2 launch super_odometry livox_mid360.launch.py
         <% when 'mimosa' %>
         - ros2 launch mimosa parrot_launch.py
-        - source /aas/temp_dev_ws/install/setup.bash && ros2 launch rovio rovio_node.launch.py
+        - ros2 launch rovio rovio_node.launch.py
         <% end %>
         - ros2 run imu_publisher imu_publisher --ros-args -p autopilot:=<%= autopilot %> -p drone_id:=<%= drone_id %> <%= simulated_time ? '-p use_sim_time:=true' : '' %>
   <% end %>

--- a/aircraft/aircraft_resources/scripts/inspect_topics.py
+++ b/aircraft/aircraft_resources/scripts/inspect_topics.py
@@ -1,0 +1,49 @@
+"""
+Use as:
+    python3 /aas/aircraft_resources/scripts/inspect_topics.py
+"""
+import subprocess
+
+def inspect_topics():
+    try:
+        topics = subprocess.check_output(['ros2', 'topic', 'list']).decode().split()
+    except Exception:
+        print("Failed to run 'ros2 topic list'. Did you source your ROS setup.bash?")
+        return
+
+    print(f"{'TOPIC':<60} | {'TYPE':<40} | {'PUBLISHERS (Nodes)':<40} | {'SUBSCRIBERS (Nodes)':<40}")
+    print("-" * 185)
+
+    for t in topics:
+        try:
+            info = subprocess.check_output(['ros2', 'topic', 'info', '-v', t], stderr=subprocess.DEVNULL).decode().splitlines()
+        except Exception:
+            continue
+
+        msg_type = "Unknown"
+        pubs, subs = [], []
+        current_section = None
+
+        for line in info:
+            line = line.strip()
+            if line.startswith("Type:"):
+                msg_type = line.split("Type:")[1].strip()
+            elif line.startswith("Publisher count:"):
+                current_section = "pub"
+            elif line.startswith("Subscription count:"):
+                current_section = "sub"
+            elif line.startswith("Node name:"):
+                node_name = line.split("Node name:")[1].strip()
+                if node_name != "UNKNOWN" and not node_name.startswith("_ros2cli"):
+                    if current_section == "pub":
+                        pubs.append(node_name)
+                    elif current_section == "sub":
+                        subs.append(node_name)
+
+        pub_str = ", ".join(pubs) if pubs else "None"
+        sub_str = ", ".join(subs) if subs else "None"
+
+        print(f"{t:<60} | {msg_type:<40} | {pub_str:<40} | {sub_str:<40}")
+
+if __name__ == '__main__':
+    inspect_topics()

--- a/tools_and_docs/deploy_build.sh
+++ b/tools_and_docs/deploy_build.sh
@@ -42,6 +42,7 @@ REPOS=( # Format: "URL;BRANCH;LOCAL_DIR_NAME"
   "https://github.com/superxslam/SuperOdom.git;ros2;SuperOdom"
   "https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git;main;rviz_2d_overlay_plugins"
   "https://github.com/ntnu-arl/mimosa.git;dev/ros2;mimosa"
+  "https://github.com/JacopoPan/rovio_ros2.git;feat/ros2;rovio"
 )
 
 for repo_info in "${REPOS[@]}"; do

--- a/tools_and_docs/deploy_build.sh
+++ b/tools_and_docs/deploy_build.sh
@@ -41,7 +41,7 @@ REPOS=( # Format: "URL;BRANCH;LOCAL_DIR_NAME"
   "https://github.com/MIT-SPARK/KISS-Matcher.git;main;KISS-Matcher"
   "https://github.com/superxslam/SuperOdom.git;ros2;SuperOdom"
   "https://github.com/ntnu-arl/mimosa.git;dev/ros2;mimosa"
-  "https://github.com/JacopoPan/rovio_ros2.git;feat/ros2;rovio"
+  "https://github.com/JacopoPan/rovio_ros2.git;main;rovio"
 )
 
 for repo_info in "${REPOS[@]}"; do

--- a/tools_and_docs/deploy_build.sh
+++ b/tools_and_docs/deploy_build.sh
@@ -41,6 +41,7 @@ REPOS=( # Format: "URL;BRANCH;LOCAL_DIR_NAME"
   "https://github.com/MIT-SPARK/KISS-Matcher.git;main;KISS-Matcher"
   "https://github.com/superxslam/SuperOdom.git;ros2;SuperOdom"
   "https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git;main;rviz_2d_overlay_plugins"
+  "https://github.com/ntnu-arl/mimosa.git;dev/ros2;mimosa"
 )
 
 for repo_info in "${REPOS[@]}"; do

--- a/tools_and_docs/deploy_run.sh
+++ b/tools_and_docs/deploy_run.sh
@@ -8,7 +8,7 @@ AUTOPILOT="${AUTOPILOT:-px4}" # Options: px4 (default), ardupilot
 HEADLESS="${HEADLESS:-true}" # Options: true (default), false 
 CAMERA="${CAMERA:-true}" # Options: true (default), false
 LIDAR="${LIDAR:-true}" # Options: true (default), false
-ODOM="${ODOM:-none}" # Options: none (default), openvins, fastlio, superodom
+ODOM="${ODOM:-none}" # Options: none (default), openvins, fastlio, superodom, mimosa
 #
 SIM_SUBNET="${SIM_SUBNET:-10.42}" # Simulation subnet (default = 10.42)
 AIR_SUBNET="${AIR_SUBNET:-10.22}" # Inter-vehicle subnet (default = 10.22)

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -250,7 +250,7 @@ RUN apt-get update && \
 COPY /_github_clones/open_vins /aas/github_ws/src/open_vins
 WORKDIR /aas/github_ws
 # Explicitly use bash, not sh, to source and build the workspace
-# Limit resource usage to avoid freezes on resource-constrained hosts and using flag --cmake-args -DENABLE_ARUCO_TAGS=OFF (the Jetson base image lacks libopencv-contrib-dev)
+# Limiting resource usage to avoid freezes on resource-constrained hosts and using flag --cmake-args -DENABLE_ARUCO_TAGS=OFF (the Jetson base image lacks libopencv-contrib-dev)
 RUN MAKEFLAGS='-j4' NINJAJOBS='-j4' bash -c "source /opt/ros/humble/setup.bash && colcon build --event-handlers console_cohesion+ --packages-select ov_core ov_init ov_msckf ov_eval --cmake-args -DENABLE_ARUCO_TAGS=OFF -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
 
 # Install SPARK-FAST-LIO, based on https://github.com/MIT-SPARK/spark-fast-lio#package-how-to-install
@@ -337,8 +337,8 @@ RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/
     colcon build --packages-select gtsam gtsam_points --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release \
     -DGTSAM_POSE3_EXPMAP=ON -DGTSAM_ROT3_EXPMAP=ON -DGTSAM_USE_QUATERNIONS=ON -DGTSAM_USE_SYSTEM_EIGEN=ON -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DGTSAM_WITH_TBB=OFF \
     -DBUILD_SHARED_LIBS=OFF -DGTSAM_BUILD_SHARED_LIBRARY=OFF"
-# Build the rest of the mimosa workspace with the static GTSAM from mimosa's fork
-RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
+# Build the rest of the mimosa workspace with the static GTSAM from mimosa's fork (limiting resource usage to avoid freezes on resource-constrained hosts)
+RUN MAKEFLAGS='-j4' NINJAJOBS='-j4' bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
     colcon build --packages-up-to mimosa --packages-skip gtsam gtsam_points --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
 
 ################################################################################

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -330,8 +330,8 @@ WORKDIR /aas/mimosa_custom_gtsam_ws
 # Fix ROS 2 Humble compatibility:
 # 1. mimosa expects cv_bridge.hpp (Iron/Jazzy), but Humble uses cv_bridge.h
 # 2. mimosa uses recv_timestamp (Iron/Jazzy), but Humble uses time_stamp
-RUN find /aas/mimosa_custom_gtsam_ws/src/mimosa -type f \( -name "*.hpp" -o -name "*.cpp" -o -name "*.h" \) -exec sed -i 's/cv_bridge\/cv_bridge\.hpp/cv_bridge\/cv_bridge\.h/g' {} + \
-    && find /aas/mimosa_custom_gtsam_ws/src/mimosa -type f -name "*.cpp" -exec sed -i 's/recv_timestamp/time_stamp/g' {} +
+RUN grep -rl "cv_bridge/cv_bridge.hpp" /aas/mimosa_custom_gtsam_ws/src/mimosa | xargs sed -i 's|cv_bridge/cv_bridge\.hpp|cv_bridge/cv_bridge.h|g' \
+    && grep -rl "recv_timestamp" /aas/mimosa_custom_gtsam_ws/src/mimosa | xargs sed -i 's/recv_timestamp/time_stamp/g'
 # Explicitly use bash, not sh, to source and build the workspace
 # Build mimosa's GTSAM fork and gtsam_points with -DBUILD_SHARED_LIBS=OFF -DGTSAM_BUILD_SHARED_LIBRARY=OFF, not to shadow the system-wide GTAM used by SuperOdom, KISS-Matcher
 RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && \

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -311,6 +311,8 @@ WORKDIR /aas/github_ws
 # Explicitly use bash, not sh, to source and build the workspace, pass CMAKE_POLICY_VERSION_MINIMUM as env var for nested builds
 RUN CMAKE_POLICY_VERSION_MINIMUM=3.5 bash -c "source /opt/ros/humble/setup.bash && colcon build --packages-select kiss_matcher_ros --cmake-args -DCMAKE_BUILD_TYPE=Release"
 
+# TODO: add https://github.com/ntnu-arl/mimosa/tree/dev/ros2
+
 ################################################################################
 # Add analysis tools and YOLO models ###########################################
 ################################################################################

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -316,8 +316,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends libgoogle-glog-dev libspdlog-dev ros-humble-pcl-ros \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
-WORKDIR /aas/mimosa_ws/src
-COPY /_github_clones/mimosa /aas/mimosa_ws/src/mimosa
+WORKDIR /aas/mimosa_custom_gtsam_ws/src
+COPY /_github_clones/mimosa /aas/mimosa_custom_gtsam_ws/src/mimosa
 # Download config_utilities (branch: dev/mimosa), gtsam (branch: feature/imu_factor_with_gravity), and gtsam_points (branch: minimal_updated)
 RUN mkdir -p config_utilities \
     && wget -qO- https://github.com/ntnu-arl/config_utilities/archive/refs/heads/dev/mimosa.tar.gz | tar -xz -C config_utilities --strip-components=1 \
@@ -325,14 +325,21 @@ RUN mkdir -p config_utilities \
     && wget -qO- https://github.com/ntnu-arl/gtsam/archive/refs/heads/feature/imu_factor_with_gravity.tar.gz | tar -xz -C gtsam --strip-components=1 \
     && mkdir -p gtsam_points \
     && wget -qO- https://github.com/ntnu-arl/gtsam_points/archive/refs/heads/minimal_updated.tar.gz | tar -xz -C gtsam_points --strip-components=1
-WORKDIR /aas/mimosa_ws
+WORKDIR /aas/mimosa_custom_gtsam_ws
 # Fix ROS 2 Humble compatibility:
 # 1. mimosa expects cv_bridge.hpp (Iron/Jazzy), but Humble uses cv_bridge.h
 # 2. mimosa uses recv_timestamp (Iron/Jazzy), but Humble uses time_stamp
-RUN find /aas/mimosa_ws/src/mimosa -type f \( -name "*.hpp" -o -name "*.cpp" -o -name "*.h" \) -exec sed -i 's/cv_bridge\/cv_bridge\.hpp/cv_bridge\/cv_bridge\.h/g' {} + \
-    && find /aas/mimosa_ws/src/mimosa -type f -name "*.cpp" -exec sed -i 's/recv_timestamp/time_stamp/g' {} +
+RUN find /aas/mimosa_custom_gtsam_ws/src/mimosa -type f \( -name "*.hpp" -o -name "*.cpp" -o -name "*.h" \) -exec sed -i 's/cv_bridge\/cv_bridge\.hpp/cv_bridge\/cv_bridge\.h/g' {} + \
+    && find /aas/mimosa_custom_gtsam_ws/src/mimosa -type f -name "*.cpp" -exec sed -i 's/recv_timestamp/time_stamp/g' {} +
 # Explicitly use bash, not sh, to source and build the workspace
-RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && colcon build --packages-up-to mimosa --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DGTSAM_POSE3_EXPMAP=ON -DGTSAM_ROT3_EXPMAP=ON -DGTSAM_USE_QUATERNIONS=ON -DGTSAM_USE_SYSTEM_EIGEN=ON -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DGTSAM_WITH_TBB=OFF"
+# Build mimosa's GTSAM fork and gtsam_points with -DBUILD_SHARED_LIBS=OFF -DGTSAM_BUILD_SHARED_LIBRARY=OFF, not to shadow the system-wide GTAM used by SuperOdom, KISS-Matcher
+RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && \
+    colcon build --packages-select gtsam gtsam_points --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release \
+    -DGTSAM_POSE3_EXPMAP=ON -DGTSAM_ROT3_EXPMAP=ON -DGTSAM_USE_QUATERNIONS=ON -DGTSAM_USE_SYSTEM_EIGEN=ON -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DGTSAM_WITH_TBB=OFF \
+    -DBUILD_SHARED_LIBS=OFF -DGTSAM_BUILD_SHARED_LIBRARY=OFF"
+# Build the rest of the mimosa workspace with the static GTSAM from mimosa's fork
+RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
+    colcon build --packages-up-to mimosa --packages-skip gtsam gtsam_points --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
 
 ################################################################################
 # Add analysis tools and YOLO models ###########################################
@@ -386,9 +393,9 @@ COPY simulation/simulation_resources/aircraft_models/sensor_config.yaml /aas/air
 
 # Source the workspaces
 RUN echo "source /aas/github_ws/install/setup.bash" >> /root/.bashrc \
-    && echo "source /aas/mimosa_ws/install/setup.bash" >> /root/.bashrc \
+    && echo "source /aas/mimosa_custom_gtsam_ws/install/setup.bash" >> /root/.bashrc \
     && echo "source /aas/aircraft_ws/install/setup.bash" >> /root/.bashrc
-# If needed (but already in .bashrc) $ source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/aircraft_ws/install/setup.bash
+# If needed (but already in .bashrc) $ source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && source /aas/aircraft_ws/install/setup.bash
 
 # Final config
 WORKDIR /aas

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -311,7 +311,28 @@ WORKDIR /aas/github_ws
 # Explicitly use bash, not sh, to source and build the workspace, pass CMAKE_POLICY_VERSION_MINIMUM as env var for nested builds
 RUN CMAKE_POLICY_VERSION_MINIMUM=3.5 bash -c "source /opt/ros/humble/setup.bash && colcon build --packages-select kiss_matcher_ros --cmake-args -DCMAKE_BUILD_TYPE=Release"
 
-# TODO: add https://github.com/ntnu-arl/mimosa/tree/dev/ros2
+# Install mimosa, based on https://github.com/ntnu-arl/mimosa/tree/dev/ros2#common-setup
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends libgoogle-glog-dev libspdlog-dev ros-humble-pcl-ros \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /aas/mimosa_ws/src
+COPY /_github_clones/mimosa /aas/mimosa_ws/src/mimosa
+# Download config_utilities (branch: dev/mimosa), gtsam (branch: feature/imu_factor_with_gravity), and gtsam_points (branch: minimal_updated)
+RUN mkdir -p config_utilities \
+    && wget -qO- https://github.com/ntnu-arl/config_utilities/archive/refs/heads/dev/mimosa.tar.gz | tar -xz -C config_utilities --strip-components=1 \
+    && mkdir -p gtsam \
+    && wget -qO- https://github.com/ntnu-arl/gtsam/archive/refs/heads/feature/imu_factor_with_gravity.tar.gz | tar -xz -C gtsam --strip-components=1 \
+    && mkdir -p gtsam_points \
+    && wget -qO- https://github.com/ntnu-arl/gtsam_points/archive/refs/heads/minimal_updated.tar.gz | tar -xz -C gtsam_points --strip-components=1
+WORKDIR /aas/mimosa_ws
+# Fix ROS 2 Humble compatibility:
+# 1. mimosa expects cv_bridge.hpp (Iron/Jazzy), but Humble uses cv_bridge.h
+# 2. mimosa uses recv_timestamp (Iron/Jazzy), but Humble uses time_stamp
+RUN find /aas/mimosa_ws/src/mimosa -type f \( -name "*.hpp" -o -name "*.cpp" -o -name "*.h" \) -exec sed -i 's/cv_bridge\/cv_bridge\.hpp/cv_bridge\/cv_bridge\.h/g' {} + \
+    && find /aas/mimosa_ws/src/mimosa -type f -name "*.cpp" -exec sed -i 's/recv_timestamp/time_stamp/g' {} +
+# Explicitly use bash, not sh, to source and build the workspace
+RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && colcon build --packages-up-to mimosa --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DGTSAM_POSE3_EXPMAP=ON -DGTSAM_ROT3_EXPMAP=ON -DGTSAM_USE_QUATERNIONS=ON -DGTSAM_USE_SYSTEM_EIGEN=ON -DGTSAM_BUILD_WITH_MARCH_NATIVE=OFF -DGTSAM_BUILD_EXAMPLES_ALWAYS=OFF -DGTSAM_WITH_TBB=OFF"
 
 ################################################################################
 # Add analysis tools and YOLO models ###########################################
@@ -365,6 +386,7 @@ COPY simulation/simulation_resources/aircraft_models/sensor_config.yaml /aas/air
 
 # Source the workspaces
 RUN echo "source /aas/github_ws/install/setup.bash" >> /root/.bashrc \
+    && echo "source /aas/mimosa_ws/install/setup.bash" >> /root/.bashrc \
     && echo "source /aas/aircraft_ws/install/setup.bash" >> /root/.bashrc
 # If needed (but already in .bashrc) $ source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/aircraft_ws/install/setup.bash
 

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -341,6 +341,25 @@ RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/
 RUN MAKEFLAGS='-j4' NINJAJOBS='-j4' bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
     colcon build --packages-up-to mimosa --packages-skip gtsam gtsam_points --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
 
+# Install rovio (custom ROS 2 porting of https://github.com/ethz-asl/rovio hosted on on https://github.com/JacopoPan/rovio_ros2)
+WORKDIR /aas/github_apps/
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends freeglut3-dev libglew-dev \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir kindr \
+    && wget -qO- https://github.com/ethz-asl/kindr/archive/refs/heads/master.tar.gz | tar -xz -C kindr --strip-components=1 \
+    && cd kindr \
+    && mkdir build && cd build \
+    && cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+    && make install
+COPY /_github_clones/rovio /aas/temp_dev_ws/src/rovio
+WORKDIR /aas/temp_dev_ws
+# Explicitly use bash, not sh, to source and build the workspace
+RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
+    # colcon build --packages-up-to rovio --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
+    colcon build --packages-select rovio_interfaces --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
+
 ################################################################################
 # Add analysis tools and YOLO models ###########################################
 ################################################################################

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -358,7 +358,7 @@ COPY /_github_clones/rovio /aas/temp_dev_ws/src/rovio
 WORKDIR /aas/temp_dev_ws
 # Explicitly use bash, not sh, to source and build the workspace
 RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
-    colcon build --packages-up-to rovio --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DENABLE_VALGRIND_COMPATIBILITY=OFF"
+    colcon build --packages-up-to rovio --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DMAKE_SCENE=ON -DENABLE_VALGRIND_COMPATIBILITY=OFF"
 
 ################################################################################
 # Add analysis tools and YOLO models ###########################################

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -354,8 +354,8 @@ RUN apt-get update && \
     && mkdir build && cd build \
     && cmake .. -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
     && make install
-COPY /_github_clones/rovio /aas/temp_dev_ws/src/rovio
-WORKDIR /aas/temp_dev_ws
+COPY /_github_clones/rovio /aas/github_ws/src/rovio
+WORKDIR /aas/github_ws
 # Explicitly use bash, not sh, to source and build the workspace
 RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
     colcon build --packages-up-to rovio --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DMAKE_SCENE=ON -DENABLE_VALGRIND_COMPATIBILITY=OFF"

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -343,6 +343,7 @@ RUN MAKEFLAGS='-j4' NINJAJOBS='-j4' bash -c "source /opt/ros/humble/setup.bash &
     colcon build --packages-up-to mimosa --packages-skip gtsam gtsam_points --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
 
 # Install rovio (ROS 2 porting of https://github.com/ethz-asl/rovio), based on https://github.com/JacopoPan/rovio_ros2#installation
+# Note: to use 'valgrind_rovio.launch.py' also 'apt-get install valgrind' and add 'mno-avx512f' after '-march=native' in CMakeLists.txt
 RUN apt-get update && \
     apt-get install -y --no-install-recommends freeglut3-dev libglew-dev \
     && apt clean \

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -342,8 +342,7 @@ RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/
 RUN MAKEFLAGS='-j4' NINJAJOBS='-j4' bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
     colcon build --packages-up-to mimosa --packages-skip gtsam gtsam_points --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
 
-# Install rovio (custom ROS 2 porting of https://github.com/ethz-asl/rovio hosted on on https://github.com/JacopoPan/rovio_ros2)
-WORKDIR /aas/github_apps/
+# Install rovio (ROS 2 porting of https://github.com/ethz-asl/rovio), based on https://github.com/JacopoPan/rovio_ros2#installation
 RUN apt-get update && \
     apt-get install -y --no-install-recommends freeglut3-dev libglew-dev \
     && apt clean \

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -358,8 +358,7 @@ COPY /_github_clones/rovio /aas/temp_dev_ws/src/rovio
 WORKDIR /aas/temp_dev_ws
 # Explicitly use bash, not sh, to source and build the workspace
 RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
-    # colcon build --packages-up-to rovio --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
-    colcon build --packages-select rovio_interfaces --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
+    colcon build --packages-up-to rovio --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
 
 ################################################################################
 # Add analysis tools and YOLO models ###########################################

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -343,9 +343,9 @@ RUN MAKEFLAGS='-j4' NINJAJOBS='-j4' bash -c "source /opt/ros/humble/setup.bash &
     colcon build --packages-up-to mimosa --packages-skip gtsam gtsam_points --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
 
 # Install rovio (ROS 2 porting of https://github.com/ethz-asl/rovio), based on https://github.com/JacopoPan/rovio_ros2#installation
-# Note: to use 'valgrind_rovio.launch.py' also 'apt-get install valgrind' and add 'mno-avx512f' after '-march=native' in CMakeLists.txt
 RUN apt-get update && \
     apt-get install -y --no-install-recommends freeglut3-dev libglew-dev \
+    # valgrind \
     && apt clean \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir kindr \
@@ -358,7 +358,7 @@ COPY /_github_clones/rovio /aas/temp_dev_ws/src/rovio
 WORKDIR /aas/temp_dev_ws
 # Explicitly use bash, not sh, to source and build the workspace
 RUN bash -c "source /opt/ros/humble/setup.bash && source /aas/github_ws/install/setup.bash && source /aas/mimosa_custom_gtsam_ws/install/setup.bash && \
-    colcon build --packages-up-to rovio --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release"
+    colcon build --packages-up-to rovio --cmake-args -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_BUILD_TYPE=Release -DENABLE_VALGRIND_COMPATIBILITY=OFF"
 
 ################################################################################
 # Add analysis tools and YOLO models ###########################################

--- a/tools_and_docs/sim_build.sh
+++ b/tools_and_docs/sim_build.sh
@@ -49,6 +49,7 @@ REPOS=( # Format: "URL;BRANCH;LOCAL_DIR_NAME"
   "https://github.com/superxslam/SuperOdom.git;ros2;SuperOdom"
   "https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git;main;rviz_2d_overlay_plugins"
   "https://github.com/ntnu-arl/mimosa.git;dev/ros2;mimosa"
+  "https://github.com/JacopoPan/rovio_ros2.git;feat/ros2;rovio"
 )
 
 for repo_info in "${REPOS[@]}"; do

--- a/tools_and_docs/sim_build.sh
+++ b/tools_and_docs/sim_build.sh
@@ -48,7 +48,7 @@ REPOS=( # Format: "URL;BRANCH;LOCAL_DIR_NAME"
   "https://github.com/MIT-SPARK/KISS-Matcher.git;main;KISS-Matcher"
   "https://github.com/superxslam/SuperOdom.git;ros2;SuperOdom"
   "https://github.com/ntnu-arl/mimosa.git;dev/ros2;mimosa"
-  "https://github.com/JacopoPan/rovio_ros2.git;feat/ros2;rovio"
+  "https://github.com/JacopoPan/rovio_ros2.git;main;rovio"
 )
 
 for repo_info in "${REPOS[@]}"; do

--- a/tools_and_docs/sim_build.sh
+++ b/tools_and_docs/sim_build.sh
@@ -48,6 +48,7 @@ REPOS=( # Format: "URL;BRANCH;LOCAL_DIR_NAME"
   "https://github.com/MIT-SPARK/KISS-Matcher.git;main;KISS-Matcher"
   "https://github.com/superxslam/SuperOdom.git;ros2;SuperOdom"
   "https://github.com/teamspatzenhirn/rviz_2d_overlay_plugins.git;main;rviz_2d_overlay_plugins"
+  "https://github.com/ntnu-arl/mimosa.git;dev/ros2;mimosa"
 )
 
 for repo_info in "${REPOS[@]}"; do

--- a/tools_and_docs/sim_run.sh
+++ b/tools_and_docs/sim_run.sh
@@ -8,7 +8,7 @@ AUTOPILOT="${AUTOPILOT:-px4}" # Options: px4 (default), ardupilot
 HEADLESS="${HEADLESS:-false}" # Options: true, false (default)
 CAMERA="${CAMERA:-true}" # Options: true (default), false
 LIDAR="${LIDAR:-true}" # Options: true (default), false 
-ODOM="${ODOM:-none}" # Options: none (default), openvins, fastlio, superodom
+ODOM="${ODOM:-none}" # Options: none (default), openvins, fastlio, superodom, mimosa
 #
 SIM_SUBNET="${SIM_SUBNET:-10.42}" # Simulation subnet (default = 10.42) Note: this is overridden if INSTANCE != 0
 AIR_SUBNET="${AIR_SUBNET:-10.22}" # Inter-vehicle subnet (default = 10.22) Note: this is overridden if INSTANCE != 0


### PR DESCRIPTION
Follows #83 

TODOs
- [x] Add `dev/ros2` branch of [mimosa](https://github.com/ntnu-arl/mimosa/tree/dev/ros2)
- [x] Test `mimosa` build on arm64/L4T base image ([action](https://github.com/JacopoPan/aerial-autonomy-stack/actions/runs/26848490398))
- [x] Compiling the `mimosa_ws` leads to runtime errors for SuperOdom and KISS-MATCHER
  - *While the impact is minor (few would actually need to build all packages in the same image), this is annoying...*
  - [x] Resolve GTSAM symbol link incompatibility between SuperOdom/KISS-MATCHER and mimosa
- [x] Add [`rovio`](https://github.com/ethz-asl/rovio)
  - [x] [`kindr `](https://github.com/ethz-asl/kindr) (library)
  - [x] [`maplab_lightweight_filtering`](https://github.com/ethz-asl/maplab_lightweight_filtering/tree/0c8517a5eb19a00a4f8d36dac4ffdc45dac6a363) (submodule)
  - [x] ROS2 fork https://github.com/JacopoPan/rovio_ros2/pull/2 (compiling on `amd64`, `arm64`/Jetson, tested)
  - [x] Move to `github_ws/`

Next steps:
- [ ] Interface synthetic sensor data (IMU, camera, LiDAR)/TF
- [ ] Create a 3D world.sdf for LIVO-based navigation and mapping (i.e., textured and obstacle rich, e.g. [`subt_cave_sim`](https://github.com/ntnu-arl/subt_cave_sim))
- [ ] Update instructions/dependencies/external repos/build times in README
- [ ] Update architectural diagram
- [ ] Use LIVO for PX4/ArduPilot SITL control (e.g., [PX4-Multiagent-Simulation](https://github.com/TannerGilbert/PX4-Multiagent-Simulation), [Ardupilot_Multiagent_Simulation](https://github.com/aau-cns/Ardupilot_Multiagent_Simulation))
- [ ] (?) Add DeepStream to amd64 build
- [ ] (?) ArUco OpenCV module on L4T of OpenVINS
- [ ] (?) Add [VSLAM-LAB](https://github.com/VSLAM-LAB/VSLAM-LAB)