### PR TITLE
Offboard Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cd aerial-autonomy-stack/tools_and_docs/
 AUTOPILOT=px4 NUM_QUADS=1 NUM_VTOLS=1 WORLD=swiss_town HEADLESS=false RTF=3.0 ./sim_run.sh    # Start a simulation, check the script for more options (note: ArduPilot SITL checks take ~30s of simulated time before being ready to arm)
 ```
 
-There are 3 ways to autonomously fly the drones (plus QGroundControl):
+There are **3 ways** to autonomously fly the drones (plus QGroundControl):
 
 1. From the `Ground`'s Xterm terminal, fly all drones in a **synchronized formation**:
 ```sh

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cd aerial-autonomy-stack/tools_and_docs/
 AUTOPILOT=px4 NUM_QUADS=1 NUM_VTOLS=1 WORLD=swiss_town HEADLESS=false RTF=3.0 ./sim_run.sh    # Start a simulation, check the script for more options (note: ArduPilot SITL checks take ~30s of simulated time before being ready to arm)
 ```
 
-In the `Ground`'s Xterm terminal, fly all drones in a coordinated formation:
+From the `Ground`'s Xterm terminal, fly all drones in a coordinated formation:
 
 ```sh
 ros2 run drone_traffic_controller dtc_controller --ros-args -p use_sim_time:=true

--- a/README.md
+++ b/README.md
@@ -82,9 +82,13 @@ ros2 run mission mission --conops yalla.yaml --ros-args -r __ns:=/Drone$ID -p us
 
 3. In any of the `QUAD`/`VTOL` Xterm terminals, use AAS ROS2 actions and services:
 ```sh
-cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/takeoff_action autopilot_interface_msgs/action/Takeoff '{takeoff_altitude: 40.0}'"
+cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/takeoff_action \
+    autopilot_interface_msgs/action/Takeoff '{takeoff_altitude: 40.0}'"
 # Press Enter to cancel the action or regain the terminal when it finishes
-cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action autopilot_interface_msgs/action/Offboard '{controller_name: traj-test-quad, max_duration_sec: 5.0}'"
+
+cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action \
+    autopilot_interface_msgs/action/Offboard \
+    '{controller_name: traj-test-quad, max_duration_sec: 10.0}'"
 ```
 
 `./sim_run.sh` options:

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ ros2 run drone_traffic_controller dtc_controller --ros-args -p use_sim_time:=tru
 ros2 run mission mission --conops yalla.yaml --ros-args -r __ns:=/Drone$ID -p use_sim_time:=true
 ```
 
-3. In any of the `QUAD`/`VTOL` Xterm terminals, use AAS ROS2 actions and services:
+3. In any of the `QUAD`/`VTOL` Xterm terminals, use AAS ROS2 actions:
 ```sh
 cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/takeoff_action \
     autopilot_interface_msgs/action/Takeoff '{takeoff_altitude: 40.0}'"
@@ -89,6 +89,7 @@ cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/takeoff_action \
 cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action \
     autopilot_interface_msgs/action/Offboard \
     '{controller_name: traj-test-quad, max_duration_sec: 10.0}'"
+# Add or re-implement offboard controllers in `px4_offboard.cpp`, `ardupilot_guided.cpp`
 ```
 
 `./sim_run.sh` options:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cd aerial-autonomy-stack/tools_and_docs/
 AUTOPILOT=px4 NUM_QUADS=1 NUM_VTOLS=1 WORLD=swiss_town HEADLESS=false RTF=3.0 ./sim_run.sh    # Start a simulation, check the script for more options (note: ArduPilot SITL checks take ~30s of simulated time before being ready to arm)
 ```
 
-There are **3 ways** to autonomously fly the drones (plus QGroundControl):
+There are **3 ways** to autonomously fly the drones (plus QGroundControl)
 
 1. From the `Ground`'s Xterm terminal, fly all drones in a **synchronized formation**:
 ```sh

--- a/README.md
+++ b/README.md
@@ -68,10 +68,23 @@ cd aerial-autonomy-stack/tools_and_docs/
 AUTOPILOT=px4 NUM_QUADS=1 NUM_VTOLS=1 WORLD=swiss_town HEADLESS=false RTF=3.0 ./sim_run.sh    # Start a simulation, check the script for more options (note: ArduPilot SITL checks take ~30s of simulated time before being ready to arm)
 ```
 
-From the `Ground`'s Xterm terminal, fly all drones in a coordinated formation:
+There are 3 ways (plus QGroundControl) to autonomously fly the drones:
 
+1. From the `Ground`'s Xterm terminal, fly all drones in a coordinated formation:
 ```sh
 ros2 run drone_traffic_controller dtc_controller --ros-args -p use_sim_time:=true
+```
+
+2. In any of the `QUAD`/`VTOL` Xterm terminals, fly a pre-planned (e.g., [`yalla.yaml`](/aircraft/aircraft_resources/missions/yalla.yaml)) mission:
+```sh
+ros2 run mission mission --conops yalla.yaml --ros-args -r __ns:=/Drone$ID -p use_sim_time:=true
+```
+
+3. In any of the `QUAD`/`VTOL` Xterm terminals, use AAS ROS2 actions and services:
+```sh
+cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/takeoff_action autopilot_interface_msgs/action/Takeoff '{takeoff_altitude: 40.0}'"
+# Press Enter to cancel the action or regain the terminal when it finishes
+cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action autopilot_interface_msgs/action/Offboard '{controller_name: traj-test-quad, max_duration_sec: 5.0}'"
 ```
 
 `./sim_run.sh` options:
@@ -115,8 +128,8 @@ ros2 run drone_traffic_controller dtc_controller --ros-args -p use_sim_time:=tru
 > # Reposition service (quads only)
 > ros2 service call /Drone${DRONE_ID}/set_reposition autopilot_interface_msgs/srv/SetReposition '{east: 50.0, north: 100.0, altitude: 60.0}'
 >
-> # Offboard action (Specify the flight behavior via 'controller_name', e.g., "traj-test-quad", "traj-test-vtol" for PX4 and "vel-test" for ArduPilot) 
-> cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action autopilot_interface_msgs/action/Offboard '{controller_name: \"traj-test-quad\", max_duration_sec: 5.0}'"
+> # Offboard action (Specify the flight behavior via `controller_name`, e.g., "traj-test-quad", "traj-test-vtol" for PX4 or "vel-test" for ArduPilot)
+> cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action autopilot_interface_msgs/action/Offboard '{controller_name: traj-test-quad, max_duration_sec: 5.0}'"
 >
 > # SetSpeed service (always limited by the autopilot params, for quads applies from the next command, not effective on ArduPilot VTOLs) 
 > ros2 service call /Drone${DRONE_ID}/set_speed autopilot_interface_msgs/srv/SetSpeed '{speed: 3.0}'
@@ -129,11 +142,6 @@ ros2 run drone_traffic_controller dtc_controller --ros-args -p use_sim_time:=tru
 > ```sh
 > /aas/simulation_resources/scripts/plot_logs.sh                                                # Analyze the flight logs at http://10.42.90.100:5006/browse or in MAVExplorer
 > ```
-> To fly a pre-planned mission, in any of the `QUAD`/`VTOL` Xterm terminals:
-> ```sh
-> ros2 run mission mission --conops yalla.yaml --ros-args -r __ns:=/Drone$ID -p use_sim_time:=true
-> ```
-> To create a new mission, re-implement [`yalla.yaml`](/aircraft/aircraft_resources/missions/yalla.yaml)
 > </details>
 > <details>
 > <summary>Add or disable <b>wind effects</b>, in the <kbd>Simulation</kbd>'s Xterm terminal <i>(click to expand)</i></summary>
@@ -347,16 +355,17 @@ flowchart TB
             end
             zenoh_air{{zenoh-bridge}}:::bridge
             subgraph control [Control]
-                mission(mission):::algo
                 dtc_client(dtc_client):::algo
+                mission(mission):::algo
                 offboard_control(offboard_control):::algo
                 autopilot_interface(autopilot_interface):::algo
                 state_sharing(state_sharing):::algo
             end
             ap_link{{"uxrce_dds <br/> || MAVROS"}}:::bridge
 
-            zenoh_air --> |"/dtc_commands"| dtc_client
             kiss_icp -.-> |"/TBD"| ap_link
+            zenoh_air --> |"/tracks"| offboard_control
+            zenoh_air --> |"/dtc_commands"| dtc_client
             ap_link --> state_sharing
             ap_link <--> autopilot_interface
             yolo_py --> |"/detections"| offboard_control
@@ -364,13 +373,11 @@ flowchart TB
             mission --> |"ros2 action/srv"| autopilot_interface
             dtc_client --> |"ros2 action/srv"| autopilot_interface
             zenoh_air <--> |"/state_drone_n"| state_sharing
+            autopilot_interface ~~~ state_sharing
         end
 
-        repo(((aerial#nbsp;autonomy#nbsp;stack)))
     end
 
-    repo ~~~ gz
-    autopilot_interface ~~~ state_sharing
     gz --> |"/lidar_points <br/> [SIM_SUBNET]"| kiss_icp
     gz --> |"gz_gst_bridge <br/> [SIM_SUBNET]"| yolo_py
     sitl <--> |"UDP <br/> [SIM_SUBNET]"| ap_link
@@ -380,15 +387,10 @@ flowchart TB
     classDef bridge fill:#ffebd6,stroke:#f5a623,stroke-width:2px;
     classDef algo fill:#e1f5fe,stroke:#0277bd,stroke-width:2px;
     classDef resource fill:#e8f5e9,stroke:#2e7d32,stroke-width:2px;
-    classDef blueStyle  fill:#e1f0ff,stroke:#666,stroke-width:2px;
-    classDef whiteStyle fill:#f9f9f9,stroke:#666,stroke-width:1px,stroke-dasharray: 5 5;
-    classDef greyStyle  fill:#eeeeee,stroke:#666,stroke-width:1px,stroke-dasharray: 5 5;
-
-    class aas,repo blueStyle;
-    class air,gnd,sim whiteStyle;
-    class perception,control,models greyStyle;
-    linkStyle 18,19,20,21 stroke:teal,stroke-width:3px;
-    linkStyle 22 stroke:blue,stroke-width:4px;
+    classDef blueStyle  fill:#e1f0ff,stroke:#666,stroke-width:2px; class aas blueStyle;
+    classDef whiteStyle fill:#f9f9f9,stroke:#666,stroke-width:1px,stroke-dasharray: 5 5; class air,gnd,sim whiteStyle;
+    classDef greyStyle  fill:#eeeeee,stroke:#666,stroke-width:1px,stroke-dasharray: 5 5; class perception,control,models greyStyle;
+    linkStyle 18,19,20,21 stroke:teal,stroke-width:3px; linkStyle 22 stroke:blue,stroke-width:4px;
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -115,8 +115,8 @@ ros2 run drone_traffic_controller dtc_controller --ros-args -p use_sim_time:=tru
 > # Reposition service (quads only)
 > ros2 service call /Drone${DRONE_ID}/set_reposition autopilot_interface_msgs/srv/SetReposition '{east: 50.0, north: 100.0, altitude: 60.0}'
 >
-> # Offboard action (PX4 quads and VTOLs offboard_setpoint_type: attitude = 0, rates = 1, trajectory = 2; ArduPilot quads offboard_setpoint_type: velocity = 3, acceleration = 4) 
-> cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action autopilot_interface_msgs/action/Offboard '{offboard_setpoint_type: 1, max_duration_sec: 5.0}'"
+> # Offboard action (Specify the flight behavior via 'controller_name', e.g., "traj-test-quad", "traj-test-vtol" for PX4 and "vel-test" for ArduPilot) 
+> cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action autopilot_interface_msgs/action/Offboard '{controller_name: \"traj-test-quad\", max_duration_sec: 5.0}'"
 >
 > # SetSpeed service (always limited by the autopilot params, for quads applies from the next command, not effective on ArduPilot VTOLs) 
 > ros2 service call /Drone${DRONE_ID}/set_speed autopilot_interface_msgs/srv/SetSpeed '{speed: 3.0}'

--- a/README.md
+++ b/README.md
@@ -68,19 +68,19 @@ cd aerial-autonomy-stack/tools_and_docs/
 AUTOPILOT=px4 NUM_QUADS=1 NUM_VTOLS=1 WORLD=swiss_town HEADLESS=false RTF=3.0 ./sim_run.sh    # Start a simulation, check the script for more options (note: ArduPilot SITL checks take ~30s of simulated time before being ready to arm)
 ```
 
-There are 3 ways (plus QGroundControl) to autonomously fly the drones:
+There are 3 ways to autonomously fly the drones (plus QGroundControl):
 
-1. From the `Ground`'s Xterm terminal, fly all drones in a coordinated formation:
+1. From the `Ground`'s Xterm terminal, fly all drones in a **synchronized formation**:
 ```sh
 ros2 run drone_traffic_controller dtc_controller --ros-args -p use_sim_time:=true
 ```
 
-2. In any of the `QUAD`/`VTOL` Xterm terminals, fly a pre-planned (e.g., [`yalla.yaml`](/aircraft/aircraft_resources/missions/yalla.yaml)) mission:
+2. In any of the `QUAD`/`VTOL` Xterm terminals, fly a **pre-planned mission** (e.g., [`yalla.yaml`](/aircraft/aircraft_resources/missions/yalla.yaml)):
 ```sh
 ros2 run mission mission --conops yalla.yaml --ros-args -r __ns:=/Drone$ID -p use_sim_time:=true
 ```
 
-3. In any of the `QUAD`/`VTOL` Xterm terminals, use AAS ROS2 actions:
+3. In any of the `QUAD`/`VTOL` Xterm terminals, use AAS **ROS2 actions**:
 ```sh
 cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/takeoff_action \
     autopilot_interface_msgs/action/Takeoff '{takeoff_altitude: 40.0}'"

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/takeoff_action \
 
 cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action \
     autopilot_interface_msgs/action/Offboard \
-    '{controller_name: traj-test-quad, max_duration_sec: 10.0}'"
+    '{controller_name: att-test, max_duration_sec: 10.0}'"
 # Add or re-implement offboard controllers in `px4_offboard.cpp`, `ardupilot_guided.cpp`
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ ros2 run drone_traffic_controller dtc_controller --ros-args -p use_sim_time:=tru
 ros2 run mission mission --conops yalla.yaml --ros-args -r __ns:=/Drone$ID -p use_sim_time:=true
 ```
 
-3. In any of the `QUAD`/`VTOL` Xterm terminals, use AAS **ROS2 actions**:
+3. In any of the `QUAD`/`VTOL` Xterm terminals, use AAS **ROS2 actions** for [`px4_offboard`](/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp)/[`ardupilot_guided`](/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp) modes
 ```sh
 cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/takeoff_action \
-    autopilot_interface_msgs/action/Takeoff '{takeoff_altitude: 40.0}'"
+    autopilot_interface_msgs/action/Takeoff '{takeoff_altitude: 30.0}'"
 # Press Enter to cancel the action or regain the terminal when it finishes
 
 cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action \
@@ -133,8 +133,8 @@ cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action \
 > # Reposition service (quads only)
 > ros2 service call /Drone${DRONE_ID}/set_reposition autopilot_interface_msgs/srv/SetReposition '{east: 50.0, north: 100.0, altitude: 60.0}'
 >
-> # Offboard action (Specify the flight behavior via `controller_name`, e.g., "traj-test-quad", "traj-test-vtol" for PX4 or "vel-test" for ArduPilot)
-> cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action autopilot_interface_msgs/action/Offboard '{controller_name: traj-test-quad, max_duration_sec: 5.0}'"
+> # Offboard action (Specify the flight behavior via `controller_name`, e.g., "traj-test" for PX4 or "vel-test" for ArduPilot)
+> cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action autopilot_interface_msgs/action/Offboard '{controller_name: traj-test, max_duration_sec: 5.0}'"
 >
 > # SetSpeed service (always limited by the autopilot params, for quads applies from the next command, not effective on ArduPilot VTOLs) 
 > ros2 service call /Drone${DRONE_ID}/set_speed autopilot_interface_msgs/srv/SetSpeed '{speed: 3.0}'

--- a/aircraft/aircraft_resources/missions/test.yaml
+++ b/aircraft/aircraft_resources/missions/test.yaml
@@ -38,7 +38,7 @@ steps:
 
   - action: offboard
     params:
-     # offboard_setpoint_type: -1 # Use default based on autopilot
+     # controller_name: "traj-test-quad" # Use default based on autopilot if omitted
      max_duration_sec: 10.0
       
   - action: land

--- a/aircraft/aircraft_resources/missions/test.yaml
+++ b/aircraft/aircraft_resources/missions/test.yaml
@@ -38,7 +38,7 @@ steps:
 
   - action: offboard
     params:
-     # controller_name: "traj-test-quad" # Use default based on autopilot if omitted
+     # controller_name: "" # Use a default in mission_node.py if omitted
      max_duration_sec: 10.0
       
   - action: land

--- a/aircraft/aircraft_resources/patches/apm_pluginlists.yaml
+++ b/aircraft/aircraft_resources/patches/apm_pluginlists.yaml
@@ -34,6 +34,7 @@
       - setpoint_position # For sending position commands
       - setpoint_velocity # For sending velocity commands
       - setpoint_accel    # For sending acceleration commands
+      - setpoint_raw      # For sending raw commands (e.g., attitude or rates, different from the setpoint_attitude plugin)
       - waypoint          # For mission manipulation
       - rc_io             # For RC override
       - vfr_hud           # For airspeed and altitude info

--- a/aircraft/aircraft_resources/scripts/gymnasium_setup.py
+++ b/aircraft/aircraft_resources/scripts/gymnasium_setup.py
@@ -54,7 +54,7 @@ class GymnasiumSetup(Node):
         self.wait_for_server(self.offboard_client, 'Offboard')
 
         goal_msg = Offboard.Goal()
-        goal_msg.offboard_setpoint_type = 1 # 1 is PX4 rates reference
+        goal_msg.controller_name = "ctbr-test-quad"
         goal_msg.max_duration_sec = 1200.0 # 20' of offboard mode
 
         self.get_logger().info('Sending Offboard Goal...')

--- a/aircraft/aircraft_resources/scripts/gymnasium_setup.py
+++ b/aircraft/aircraft_resources/scripts/gymnasium_setup.py
@@ -54,7 +54,7 @@ class GymnasiumSetup(Node):
         self.wait_for_server(self.offboard_client, 'Offboard')
 
         goal_msg = Offboard.Goal()
-        goal_msg.controller_name = "ctbr-test-quad"
+        goal_msg.controller_name = "ctbr-test" # See px4_offboard.cpp
         goal_msg.max_duration_sec = 1200.0 # 20' of offboard mode
 
         self.get_logger().info('Sending Offboard Goal...')

--- a/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
@@ -2,7 +2,7 @@
 
 ArdupilotInterface::ArdupilotInterface() : Node("ardupilot_interface"),
     active_srv_or_act_flag_(false), aircraft_fsm_state_(ArdupilotInterfaceState::STARTED),
-    offboard_flag_frequency(10), offboard_flag_count_(0), last_offboard_flag_count_(0),
+    active_offboard_controller_name_(""), offboard_flag_frequency(10), offboard_flag_count_(0), last_offboard_flag_count_(0),
     target_system_id_(-1), mav_state_(-1), mav_type_(-1),
     armed_flag_(false), ardupilot_mode_(""),
     lat_(NAN), lon_(NAN), alt_(NAN), alt_ellipsoid_(NAN),
@@ -274,12 +274,12 @@ void ArdupilotInterface::offboard_flag_callback()
 
     auto msg = autopilot_interface_msgs::msg::OffboardFlag();
     std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
-    if (aircraft_fsm_state_ == ArdupilotInterfaceState::OFFBOARD_VELOCITY) {
-        msg.offboard_flag = 7;
-    } else if (aircraft_fsm_state_ == ArdupilotInterfaceState::OFFBOARD_ACCELERATION) {
-        msg.offboard_flag = 8;
+    if (aircraft_fsm_state_ == ArdupilotInterfaceState::OFFBOARD) {
+        msg.is_active = true;
+        msg.controller_name = active_offboard_controller_name_;
     } else {
-        msg.offboard_flag = 0; // Inactive
+        msg.is_active = false;
+        msg.controller_name = "";
     }
     offboard_flag_pub_->publish(msg);
 }
@@ -609,7 +609,7 @@ void ArdupilotInterface::offboard_handle_accepted(const std::shared_ptr<rclcpp_a
     auto result = std::make_shared<autopilot_interface_msgs::action::Offboard::Result>();
     auto feedback = std::make_shared<autopilot_interface_msgs::action::Offboard::Feedback>();
 
-    int offboard_setpoint_type = goal->offboard_setpoint_type;
+    std::string requested_controller = goal->controller_name;
     double max_duration_sec = goal->max_duration_sec;
 
     offboard_flag_count_ = 0;
@@ -643,20 +643,9 @@ void ArdupilotInterface::offboard_handle_accepted(const std::shared_ptr<rclcpp_a
                     }
                 });
             std::unique_lock<std::shared_mutex> lock(node_data_mutex_); // Reading data written by subs but also writing the FSM state
-            if (offboard_setpoint_type == autopilot_interface_msgs::action::Offboard::Goal::VELOCITY) {
-                aircraft_fsm_state_ = ArdupilotInterfaceState::OFFBOARD_VELOCITY;
-                feedback->message = "Offboarding (GUIDED mode) with VELOCITY setpoints";
-            }
-            else if (offboard_setpoint_type == autopilot_interface_msgs::action::Offboard::Goal::ACCELERATION) {
-                aircraft_fsm_state_ = ArdupilotInterfaceState::OFFBOARD_ACCELERATION;
-                feedback->message = "Offboarding (GUIDED mode) with ACCELERATION setpoints";
-            }
-            else {
-                result->success = false;
-                goal_handle->canceled(result);
-                RCLCPP_ERROR(this->get_logger(), "Offboard (GUIDED mode) type is not supported by ArdupilotInterface (only VELOCITY and ACCELERATION)");
-                return;
-            }
+            aircraft_fsm_state_ = ArdupilotInterfaceState::OFFBOARD;
+            active_offboard_controller_name_ = requested_controller;
+            feedback->message = "Offboarding (GUIDED mode) with controller: " + requested_controller;
             goal_handle->publish_feedback(feedback);
             time_of_offboard_start_us_ = current_time_us;
             feedback->message = "Starting offboard control at t=" + std::to_string(time_of_offboard_start_us_) + " us";
@@ -1173,8 +1162,7 @@ std::string ArdupilotInterface::fsm_state_to_string(ArdupilotInterfaceState stat
         case ArdupilotInterfaceState::VTOL_QRTL_PARAM_SET: return "VTOL_QRTL_PARAM_SET";
         case ArdupilotInterfaceState::VTOL_QRTL: return "VTOL_QRTL";
         case ArdupilotInterfaceState::LANDED: return "LANDED";
-        case ArdupilotInterfaceState::OFFBOARD_VELOCITY: return "OFFBOARD_VELOCITY";
-        case ArdupilotInterfaceState::OFFBOARD_ACCELERATION: return "OFFBOARD_ACCELERATION";
+        case ArdupilotInterfaceState::OFFBOARD: return "OFFBOARD";
         default: return "UNKNOWN";
     }
 }

--- a/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.hpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.hpp
@@ -94,8 +94,7 @@ enum class ArdupilotInterfaceState {
     VTOL_QRTL_PARAM_SET,
     VTOL_QRTL,
     LANDED,
-    OFFBOARD_VELOCITY,
-    OFFBOARD_ACCELERATION
+    OFFBOARD
 };
 
 class ArdupilotInterface : public rclcpp::Node
@@ -140,6 +139,7 @@ private:
     std::atomic<int> offboard_flag_count_;
     std::atomic<int> last_offboard_flag_count_;
     rclcpp::Time last_offboard_flag_rate_check_time_;
+    std::string active_offboard_controller_name_;
 
     // Callback groups
     rclcpp::CallbackGroup::SharedPtr callback_group_timer_;

--- a/aircraft/aircraft_ws/src/autopilot_interface/src/px4_interface.cpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/px4_interface.cpp
@@ -2,7 +2,7 @@
 
 PX4Interface::PX4Interface() : Node("px4_interface"),
     active_srv_or_act_flag_(false), aircraft_fsm_state_(PX4InterfaceState::STARTED),
-    offboard_flag_frequency(10), offboard_flag_count_(0), last_offboard_flag_count_(0),
+    active_offboard_controller_name_(""), offboard_flag_frequency(10), offboard_flag_count_(0), last_offboard_flag_count_(0),
     target_system_id_(-1), arming_state_(-1), vehicle_type_(-1),
     is_vtol_(false), is_vtol_tailsitter_(false), in_transition_mode_(false), in_transition_to_fw_(false), pre_flight_checks_pass_(false),
     lat_(NAN), lon_(NAN), alt_(NAN), alt_ellipsoid_(NAN),
@@ -263,14 +263,12 @@ void PX4Interface::offboard_flag_callback()
 
     auto msg = autopilot_interface_msgs::msg::OffboardFlag();
     std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
-    if (aircraft_fsm_state_ == PX4InterfaceState::OFFBOARD_ATTITUDE) {
-        msg.offboard_flag = is_vtol_ ? 2 : 1;
-    } else if (aircraft_fsm_state_ == PX4InterfaceState::OFFBOARD_RATES) {
-        msg.offboard_flag = is_vtol_ ? 4 : 3;
-    } else if (aircraft_fsm_state_ == PX4InterfaceState::OFFBOARD_TRAJECTORY) {
-        msg.offboard_flag = is_vtol_ ? 6 : 5;
+    if (aircraft_fsm_state_ == PX4InterfaceState::OFFBOARD) {
+        msg.is_active = true;
+        msg.controller_name = active_offboard_controller_name_;
     } else {
-        msg.offboard_flag = 0; // Inactive
+        msg.is_active = false;
+        msg.controller_name = "";
     }
     offboard_flag_pub_->publish(msg);
 }
@@ -496,7 +494,7 @@ void PX4Interface::offboard_handle_accepted(const std::shared_ptr<rclcpp_action:
     auto result = std::make_shared<autopilot_interface_msgs::action::Offboard::Result>();
     auto feedback = std::make_shared<autopilot_interface_msgs::action::Offboard::Feedback>();
 
-    int offboard_setpoint_type = goal->offboard_setpoint_type;
+    std::string requested_controller = goal->controller_name;
     double max_duration_sec = goal->max_duration_sec;
 
     offboard_flag_count_ = 0;
@@ -519,24 +517,9 @@ void PX4Interface::offboard_handle_accepted(const std::shared_ptr<rclcpp_action:
 
         uint64_t current_time_us = this->get_clock()->now().nanoseconds() / 1000;  // Convert to microseconds
         if (time_of_offboard_start_us_ == -1) {
-            if (offboard_setpoint_type == autopilot_interface_msgs::action::Offboard::Goal::ATTITUDE) {
-                aircraft_fsm_state_ = PX4InterfaceState::OFFBOARD_ATTITUDE;
-                feedback->message = "Offboarding with ATTITUDE setpoints";
-            }
-            else if (offboard_setpoint_type == autopilot_interface_msgs::action::Offboard::Goal::RATES) {
-                aircraft_fsm_state_ = PX4InterfaceState::OFFBOARD_RATES;
-                feedback->message = "Offboarding with RATES setpoints";
-            }
-            else if (offboard_setpoint_type == autopilot_interface_msgs::action::Offboard::Goal::TRAJECTORY) {
-                aircraft_fsm_state_ = PX4InterfaceState::OFFBOARD_TRAJECTORY;
-                feedback->message = "Offboarding with TRAJECTORY setpoints";
-            }
-            else {
-                result->success = false;
-                goal_handle->canceled(result);
-                RCLCPP_ERROR(this->get_logger(), "Offboard type is not supported by PX4Interface (only ATTITUDE, RATES and TRAJECTORY)");
-                return;
-            }
+            aircraft_fsm_state_ = PX4InterfaceState::OFFBOARD;
+            active_offboard_controller_name_ = requested_controller;
+            feedback->message = "Offboarding with controller: " + requested_controller;
             goal_handle->publish_feedback(feedback);
             time_of_offboard_start_us_ = current_time_us;
             feedback->message = "Starting offboard control at t=" + std::to_string(time_of_offboard_start_us_) + " us";
@@ -927,9 +910,7 @@ std::string PX4Interface::fsm_state_to_string(PX4InterfaceState state)
         case PX4InterfaceState::VTOL_LANDING_TRANSITION: return "VTOL_LANDING_TRANSITION";
         case PX4InterfaceState::RTL: return "RTL";
         case PX4InterfaceState::MC_LANDING: return "MC_LANDING";
-        case PX4InterfaceState::OFFBOARD_ATTITUDE: return "OFFBOARD_ATTITUDE";
-        case PX4InterfaceState::OFFBOARD_RATES: return "OFFBOARD_RATES";
-        case PX4InterfaceState::OFFBOARD_TRAJECTORY: return "OFFBOARD_TRAJECTORY";
+        case PX4InterfaceState::OFFBOARD: return "OFFBOARD";
         default: return "UNKNOWN";
     }
 }

--- a/aircraft/aircraft_ws/src/autopilot_interface/src/px4_interface.hpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/px4_interface.hpp
@@ -58,9 +58,7 @@ enum class PX4InterfaceState {
     VTOL_LANDING_TRANSITION,
     RTL,
     MC_LANDING,
-    OFFBOARD_ATTITUDE,
-    OFFBOARD_RATES,
-    OFFBOARD_TRAJECTORY
+    OFFBOARD
 };
 
 class PX4Interface : public rclcpp::Node
@@ -102,6 +100,7 @@ private:
     std::atomic<int> offboard_flag_count_;
     std::atomic<int> last_offboard_flag_count_;
     rclcpp::Time last_offboard_flag_rate_check_time_;
+    std::string active_offboard_controller_name_;
 
     // Callback groups
     rclcpp::CallbackGroup::SharedPtr callback_group_timer_;

--- a/aircraft/aircraft_ws/src/autopilot_interface_msgs/action/Offboard.action
+++ b/aircraft/aircraft_ws/src/autopilot_interface_msgs/action/Offboard.action
@@ -1,10 +1,4 @@
-uint8 ATTITUDE = 0
-uint8 RATES = 1
-uint8 TRAJECTORY = 2
-uint8 VELOCITY = 3
-uint8 ACCELERATION = 4
-
-uint8 offboard_setpoint_type
+string controller_name
 float64 max_duration_sec 3.0
 ---
 bool success

--- a/aircraft/aircraft_ws/src/autopilot_interface_msgs/msg/OffboardFlag.msg
+++ b/aircraft/aircraft_ws/src/autopilot_interface_msgs/msg/OffboardFlag.msg
@@ -1,11 +1,2 @@
-uint8 INACTIVE = 0
-uint8 PX4_QUAD_ATTITUDE = 1
-uint8 PX4_VTOL_ATTITUDE = 2
-uint8 PX4_QUAD_RATES = 3
-uint8 PX4_VTOL_RATES = 4
-uint8 PX4_QUAD_TRAJECTORY = 5
-uint8 PX4_VTOL_TRAJECTORY = 6
-uint8 AP_QUAD_VELOCITY = 7
-uint8 AP_QUAD_ACCELERATION = 8
-
-uint8 offboard_flag
+bool is_active
+string controller_name

--- a/aircraft/aircraft_ws/src/drone_traffic_client/src/dtc_client_node.cpp
+++ b/aircraft/aircraft_ws/src/drone_traffic_client/src/dtc_client_node.cpp
@@ -67,7 +67,7 @@ private:
             target_vtol_loiter_n_ = cmd.value("vtol_loiter_n", 150.0f);
             target_vtol_loiter_e_ = cmd.value("vtol_loiter_e", 0.0f);
             target_vtol_loiter_alt_ = cmd.value("vtol_loiter_alt", 100.0f);
-            target_offboard_type_ = cmd.value("offboard_type", 1);
+            target_controller_name_ = cmd.value("controller_name", "");
             target_duration_ = cmd.value("duration", 3.0f);
             target_speed_  = cmd.value("speed", 5.0f);
 
@@ -126,7 +126,7 @@ private:
         } else if (target_action_ == "offboard") {
             if (!offboard_cli_->action_server_is_ready()) return;
             auto goal = autopilot_interface_msgs::action::Offboard::Goal();
-            goal.offboard_setpoint_type = target_offboard_type_;
+            goal.controller_name = target_controller_name_;
             goal.max_duration_sec = target_duration_;
             auto opts = rclcpp_action::Client<autopilot_interface_msgs::action::Offboard>::SendGoalOptions();
             opts.goal_response_callback = action_cb;
@@ -161,7 +161,7 @@ private:
     float target_alt_, target_east_, target_north_;
     float target_radius_, target_speed_, target_duration_;
     float target_vtol_heading_, target_vtol_loiter_n_, target_vtol_loiter_e_, target_vtol_loiter_alt_;
-    int target_offboard_type_;
+    std::string target_controller_name_;
     bool action_accepted_;
     bool request_being_sent_; // Prevent spamming the same command
 

--- a/aircraft/aircraft_ws/src/mission/mission/mission_node.py
+++ b/aircraft/aircraft_ws/src/mission/mission/mission_node.py
@@ -422,13 +422,18 @@ class MissionNode(Node):
             self.send_goal(self._orbit_client, goal)
             
         elif action_type == 'offboard':
-            if (os.getenv('AUTOPILOT', '') == 'ardupilot') and (os.getenv('DRONE_TYPE', '') != 'quad'):
+            autopilot = os.getenv('AUTOPILOT', '')
+            drone_type = os.getenv('DRONE_TYPE', '')
+            if (autopilot == 'ardupilot') and (drone_type != 'quad'):
                 self.get_logger().warn("Offboard action is not supported by Ardupilot VTOL. Skip.")
                 self.mission_step += 1
                 return
-            default_setpoint_type = 2 if os.getenv('AUTOPILOT', '') == 'px4' else 3 # 2: PX4 trajectory reference, 3: ArduPilot velocity
+            if autopilot == 'px4':
+                default_controller = 'traj-test-quad' if drone_type == 'quad' else 'traj-test-vtol'
+            else:
+                default_controller = 'vel-test'
             goal = Offboard.Goal()
-            goal.offboard_setpoint_type = int(params.get('offboard_setpoint_type', default_setpoint_type))
+            goal.controller_name = str(params.get('controller_name', default_controller))
             goal.max_duration_sec = float(params.get('max_duration_sec', 10.0))
             self.send_goal(self._offboard_client, goal)
 

--- a/aircraft/aircraft_ws/src/mission/mission/mission_node.py
+++ b/aircraft/aircraft_ws/src/mission/mission/mission_node.py
@@ -429,8 +429,8 @@ class MissionNode(Node):
                 self.mission_step += 1
                 return
             if autopilot == 'px4':
-                default_controller = 'traj-test-quad' if drone_type == 'quad' else 'traj-test-vtol'
-            else:
+                default_controller = 'traj-test'
+            elif autopilot == 'ardupilot':
                 default_controller = 'vel-test'
             goal = Offboard.Goal()
             goal.controller_name = str(params.get('controller_name', default_controller))

--- a/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp
@@ -1,7 +1,7 @@
 #include "ardupilot_guided.hpp"
 
 ArdupilotGuided::ArdupilotGuided() : Node("ardupilot_guided"),
-    own_id_(-1), offboard_flag_(0),
+    own_id_(-1), offboard_active_(false), active_controller_name_(""), active_controller_func_(nullptr),
     offboard_loop_frequency(10), offboard_loop_count_(0), last_offboard_loop_count_(0),
     lat_(NAN), lon_(NAN), alt_(NAN), alt_ellipsoid_(NAN),
     x_(NAN), y_(NAN), z_(NAN),  vx_(NAN), vy_(NAN), vz_(NAN), ve_(NAN), vn_(NAN), vu_(NAN),
@@ -99,6 +99,12 @@ ArdupilotGuided::ArdupilotGuided() : Node("ardupilot_guided"),
     kiss_odometry_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
         "/kiss/odometry", qos_profile_sub, // 10Hz
         std::bind(&ArdupilotGuided::kiss_odometry_callback, this, std::placeholders::_1), subscriber_options);
+
+    // Controllers map
+    controller_map_["vel-test"] = std::bind(&ArdupilotGuided::vel_ref_test, this);
+    controller_map_["vel-lp"] = std::bind(&ArdupilotGuided::vel_ref_lead_pursuit, this);
+    controller_map_["acc-test"] = std::bind(&ArdupilotGuided::acc_ref_test, this);
+    controller_map_["acc-pn"] = std::bind(&ArdupilotGuided::acc_ref_proportional_navigation, this);
 }
 
 // Callbacks for subscribers (reentrant group)
@@ -157,7 +163,21 @@ void ArdupilotGuided::vfr_hud_callback(const VfrHud::SharedPtr msg)
 void ArdupilotGuided::offboard_flag_callaback(const autopilot_interface_msgs::msg::OffboardFlag::SharedPtr msg)
 {
     std::unique_lock<std::shared_mutex> lock(node_data_mutex_); // Use unique_lock for data writes
-    offboard_flag_ = msg->offboard_flag;
+    offboard_active_ = msg->is_active;
+    if (offboard_active_) {
+        if (active_controller_name_ != msg->controller_name) { // Only perform the map lookup if the requested controller has changed
+            active_controller_name_ = msg->controller_name;
+            auto it = controller_map_.find(active_controller_name_);
+            if (it != controller_map_.end()) {
+                active_controller_func_ = it->second; // Cache the controller function
+            } else {
+                active_controller_func_ = nullptr; // Failsafe
+            }
+        }
+    } else { // Clean up when offboard flag is inactive
+        active_controller_name_ = "";
+        active_controller_func_ = nullptr;
+    }
 }
 void ArdupilotGuided::ground_tracks_callback(const ground_system_msgs::msg::SwarmObs::SharedPtr msg)
 {
@@ -240,7 +260,6 @@ void ArdupilotGuided::kiss_odometry_callback(const nav_msgs::msg::Odometry::Shar
 void ArdupilotGuided::ardupilot_interface_printout_callback()
 {
     std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
-
     auto now = this->get_clock()->now();
     double elapsed_sec = (now - last_offboard_rate_check_time_).seconds();
     double actual_rate = NAN;
@@ -252,11 +271,13 @@ void ArdupilotGuided::ardupilot_interface_printout_callback()
     RCLCPP_INFO(get_logger(),
                 "\n  Current node time: %.2f seconds\n"
                 "  KISS pos: %.2f %.2f %.2f\n"
-                "  Offboard flag:\t%d\n"
+                "  Offboard active:\t%s\n"
+                "  Controller:\t%s\n"
                 "  Offboard loop rate:\t%.2f Hz",
                 this->get_clock()->now().seconds(),
                 kiss_position_[0], kiss_position_[1], kiss_position_[2],
-                offboard_flag_.load(),
+                offboard_active_ ? "true" : "false",
+                offboard_active_ ? active_controller_name_.c_str() : "None",
                 actual_rate
             );
     std::stringstream ss;
@@ -301,150 +322,14 @@ void ArdupilotGuided::ardupilot_interface_printout_callback()
 void ArdupilotGuided::offboard_loop_callback()
 {
     offboard_loop_count_++; // Counter to monitor the rate of the offboard loop (no lock, atomic variable)
-
     std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
-    if (offboard_flag_ == 0) {
-        return; // Do not publish anything else if not in an OFFBOARD state
-    // TODO: implement custom offboard control logic here
-    } else if (offboard_flag_ == 7) { // Velocity setpoint
-        auto vel_msg = geometry_msgs::msg::TwistStamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Twist.html
-        vel_msg.header.stamp = this->get_clock()->now();
-        vel_msg.header.frame_id = "map"; // World frame, without automatic yaw alignment
-        vel_msg.twist.linear.x = 0.0; // m/s East
-        vel_msg.twist.linear.y = 5.0; // m/s North
-        vel_msg.twist.linear.z = 0.0; // m/s Up
-        ///////////////////////////////////////////////////////////////////////
-        // Lead pursuit ///////////////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        if (!std::isnan(desired_bearing_rad_) && !std::isnan(desired_elevation_rad_) && !std::isnan(closing_distance_) &&
-            !std::isnan(target_vn_) && !std::isnan(target_ve_) && !std::isnan(target_vd_)) {
-            // Calculate unit line-of-sight (LOS) vector in ENU
-            double u_E = std::cos(desired_elevation_rad_) * std::sin(desired_bearing_rad_);
-            double u_N = std::cos(desired_elevation_rad_) * std::cos(desired_bearing_rad_);
-            double u_U = std::sin(desired_elevation_rad_);
-            // Project target ENU velocity along the LOS (parallel, escape speed) and across it (perp, lateral drift speed)
-            double vt_parallel_mag = (target_ve_ * u_E) + (target_vn_ * u_N) + (-target_vd_ * u_U);
-            double vt_perp_E = target_ve_ - (vt_parallel_mag * u_E);
-            double vt_perp_N = target_vn_ - (vt_parallel_mag * u_N);
-            double vt_perp_U = -target_vd_ - (vt_parallel_mag * u_U);
-            // Distance-based desired closing speed (3m/s if closer than 5m and up to 10m/s if further than 50m)
-            double base_closing_speed = 3.0 + std::clamp((closing_distance_ - 5.0) / 50.0, 0.0, 1.0) * 7.0;
-            // Total desired speed along the LOS: target's escape speed + closing speed
-            double vd_parallel_mag = vt_parallel_mag + base_closing_speed;
-            // Final velocity reference: escape speed + closing speed + match perpendicular drift (based on pursuit type)
-            const double K_pursuit = 1.0; //  1.0 = lead pursuit (match drift, intercept target)
-                                          //  0.0 = pure pursuit (point directly at target, tail-chase)
-                                          // -0.5 = lag pursuit (fall behind target's path)
-            vel_msg.twist.linear.x = (K_pursuit * vt_perp_E) + (vd_parallel_mag * u_E); // m/s East
-            vel_msg.twist.linear.y = (K_pursuit * vt_perp_N) + (vd_parallel_mag * u_N); // m/s North
-            vel_msg.twist.linear.z = (K_pursuit * vt_perp_U) + (vd_parallel_mag * u_U); // m/s Up
-        } else { // Missing track, stay still
-            vel_msg.twist.linear.x = 0.0;
-            vel_msg.twist.linear.y = 0.0;
-            vel_msg.twist.linear.z = 0.0;
-        }
-        // Computed yaw rate for alignment
-        const double Kp_yaw = 1.5;
-        double heading_error = normalize_heading(std::atan2(vel_msg.twist.linear.y, vel_msg.twist.linear.x) - ((M_PI / 2.0) - (heading_ * M_PI / 180.0)));
-        vel_msg.twist.angular.z = Kp_yaw * heading_error; // rad/s Yaw rate
-        ///////////////////////////////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        setpoint_vel_pub_->publish(vel_msg);
-        // Alternatively, use the unstamped topic: ros2 topic pub --rate 10 --times 50 /mavros/setpoint_velocity/cmd_vel_unstamped geometry_msgs/msg/Twist '{linear: {x: 2.0, y: 0.0, z: 0.0}}'
-    } else if (offboard_flag_ == 8) { // Acceleration setpoint
-        auto accel_msg = geometry_msgs::msg::Vector3Stamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Vector3.html
-        accel_msg.header.stamp = this->get_clock()->now();
-        accel_msg.header.frame_id = "map"; // World frame, with automatic yaw alignment
-        accel_msg.vector.x = 0.0; // m/s^2 East
-        accel_msg.vector.y = 1.5; // m/s^2 North
-        accel_msg.vector.z = 0.0; // m/s^2 Up
-        ///////////////////////////////////////////////////////////////////////
-        // Proportional navigation ////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        if (!std::isnan(desired_bearing_rad_) && !std::isnan(desired_elevation_rad_) && !std::isnan(closing_distance_) &&
-            !std::isnan(target_vn_) && !std::isnan(target_ve_) && !std::isnan(target_vd_)) {
-
-            // Calculate ENU error vector
-            double r_E = closing_distance_ * std::sin(desired_bearing_rad_);
-            double r_N = closing_distance_ * std::cos(desired_bearing_rad_);
-            double r_U = closing_distance_ * std::tan(desired_elevation_rad_);
-            double distance_3d = std::max(0.1, std::hypot(closing_distance_, r_U)); // Prevent divide-by-zero
-
-            // Unit LOS Vector in ENU
-            double u_E = r_E / distance_3d;
-            double u_N = r_N / distance_3d;
-            double u_U = r_U / distance_3d;
-
-            // Relative ENU Velocity (target - own)
-            double vrel_E = target_ve_ - ve_;
-            double vrel_N = target_vn_ - vn_;
-            double vrel_U = -target_vd_ - vu_;
-
-            // Closing velocity (Vc = -(r dot vrel) / |r|)
-            double r_dot_vrel = (r_E * vrel_E) + (r_N * vrel_N) + (r_U * vrel_U);
-            double Vc = -r_dot_vrel / distance_3d;
-
-            if (Vc > 0) { // Target is closing
-                // LOS angular rate vector (omega = (r x vrel) / |r|^2)
-                double r_sq = distance_3d * distance_3d;
-                double omega_E = (r_N * vrel_U - r_U * vrel_N) / r_sq;
-                double omega_N = (r_U * vrel_E - r_E * vrel_U) / r_sq;
-                double omega_U = (r_E * vrel_N - r_N * vrel_E) / r_sq;
-
-                // PN steering acceleration (HORIZONTAL ONLY)
-                const double N_gain = 3.0;
-                double a_pn_E = N_gain * Vc * (omega_N * u_U - omega_U * u_N);
-                double a_pn_N = N_gain * Vc * (omega_U * u_E - omega_E * u_U);
-
-                // Distance-based desired closing speed (3m/s if closer than 5m and up to 10m/s if further than 50m)
-                double desired_Vc = 3.0 + std::clamp((closing_distance_ - 5.0) / 50.0, 0.0, 1.0) * 7.0;
-                // Catch-Up acceleration (HORIZONTAL ONLY)
-                double a_fwd_mag = std::clamp(0.5 * (desired_Vc - Vc), -2.0, 3.0);
-                accel_msg.vector.x = a_pn_E + (a_fwd_mag * u_E);
-                accel_msg.vector.y = a_pn_N + (a_fwd_mag * u_N);
-
-            } else { // Target is opening, just thrust in its direction (HORIZONTAL ONLY)
-                accel_msg.vector.x = u_E * 2.0;
-                accel_msg.vector.y = u_N * 2.0;
-            }
-
-            // Account for ArduPilot attitude control limits
-            constexpr double ANGLE_MAX_CDEG = 3000.0; // Note: matches param ANGLE_MAX, ensure WPNAV_ACCEL is set to 500
-            const double MAX_HORIZ_ACCEL = 9.81 * std::tan((ANGLE_MAX_CDEG / 100.0) * (M_PI / 180.0));
-            double a_horiz_mag = std::hypot(accel_msg.vector.x, accel_msg.vector.y);
-            if (a_horiz_mag > MAX_HORIZ_ACCEL) {
-                double scale = MAX_HORIZ_ACCEL / a_horiz_mag;
-                accel_msg.vector.x *= scale;
-                accel_msg.vector.y *= scale;
-            }
-
-            // Decoupled z-axis PD altitude controller (clamped to bounds)
-            const double Kp_Z = 1.0;
-            const double Kd_Z = 1.5;
-            accel_msg.vector.z = (Kp_Z * r_U) + (Kd_Z * vrel_U);
-            accel_msg.vector.z = std::clamp(accel_msg.vector.z, -1.5, 1.5);
-
-        } else { // Missing track, break
-            const double K_brake = 1.0; // Braking gain (1.0 means try to stop in ~1 second)
-            accel_msg.vector.x = -K_brake * ve_;
-            accel_msg.vector.y = -K_brake * vn_;
-            accel_msg.vector.z = -K_brake * vu_;
-            double brake_mag = std::hypot(accel_msg.vector.x, accel_msg.vector.y);
-            const double MAX_BRAKE_ACCEL = 3.0; // Clamp horizontal braking deceleration
-            if (brake_mag > MAX_BRAKE_ACCEL) {
-                double scale = MAX_BRAKE_ACCEL / brake_mag;
-                accel_msg.vector.x *= scale;
-                accel_msg.vector.y *= scale;
-            }
-            accel_msg.vector.z = std::clamp(accel_msg.vector.z, -1.0, 1.0); // Limit vertical deceleration
-        }
-        ///////////////////////////////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        setpoint_accel_pub_->publish(accel_msg);
+    if (!offboard_active_) {
+        return; // Do not publish anything else if not in OFFBOARD state
+    }
+    if (active_controller_func_ != nullptr) {
+        active_controller_func_(); // If offboard is active AND we have a valid controller, run it
     } else {
-        RCLCPP_WARN(get_logger(), "Unexpected offboard_flag value: %d", offboard_flag_.load());
+        RCLCPP_WARN(get_logger(), "Unknown controller requested: '%s', no reference will be published", active_controller_name_.c_str());
     }
 }
 
@@ -457,6 +342,151 @@ double ArdupilotGuided::normalize_heading(double angle_rad) {
         angle_rad += 2.0 * M_PI;
     }
     return angle_rad;
+}
+
+// Controllers (reference generators)
+void ArdupilotGuided::vel_ref_test()
+{
+    auto vel_msg = geometry_msgs::msg::TwistStamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Twist.html
+    vel_msg.header.stamp = this->get_clock()->now();
+    vel_msg.header.frame_id = "map"; // World frame, without automatic yaw alignment
+    vel_msg.twist.linear.x = 0.0; // m/s East
+    vel_msg.twist.linear.y = 5.0; // m/s North
+    vel_msg.twist.linear.z = 0.0; // m/s Up
+    setpoint_vel_pub_->publish(vel_msg);
+    // Alternatively, use the unstamped topic: ros2 topic pub --rate 10 --times 50 /mavros/setpoint_velocity/cmd_vel_unstamped geometry_msgs/msg/Twist '{linear: {x: 2.0, y: 0.0, z: 0.0}}'
+}
+void ArdupilotGuided::vel_ref_lead_pursuit()
+{
+    auto vel_msg = geometry_msgs::msg::TwistStamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Twist.html
+    vel_msg.header.stamp = this->get_clock()->now();
+    vel_msg.header.frame_id = "map"; // World frame, without automatic yaw alignment
+    if (!std::isnan(desired_bearing_rad_) && !std::isnan(desired_elevation_rad_) && !std::isnan(closing_distance_) &&
+        !std::isnan(target_vn_) && !std::isnan(target_ve_) && !std::isnan(target_vd_)) {
+        // Calculate unit line-of-sight (LOS) vector in ENU
+        double u_E = std::cos(desired_elevation_rad_) * std::sin(desired_bearing_rad_);
+        double u_N = std::cos(desired_elevation_rad_) * std::cos(desired_bearing_rad_);
+        double u_U = std::sin(desired_elevation_rad_);
+        // Project target ENU velocity along the LOS (parallel, escape speed) and across it (perp, lateral drift speed)
+        double vt_parallel_mag = (target_ve_ * u_E) + (target_vn_ * u_N) + (-target_vd_ * u_U);
+        double vt_perp_E = target_ve_ - (vt_parallel_mag * u_E);
+        double vt_perp_N = target_vn_ - (vt_parallel_mag * u_N);
+        double vt_perp_U = -target_vd_ - (vt_parallel_mag * u_U);
+        // Distance-based desired closing speed (3m/s if closer than 5m and up to 10m/s if further than 50m)
+        double base_closing_speed = 3.0 + std::clamp((closing_distance_ - 5.0) / 50.0, 0.0, 1.0) * 7.0;
+        // Total desired speed along the LOS: target's escape speed + closing speed
+        double vd_parallel_mag = vt_parallel_mag + base_closing_speed;
+        // Final velocity reference: escape speed + closing speed + match perpendicular drift (based on pursuit type)
+        const double K_pursuit = 1.0; //  1.0 = lead pursuit (match drift, intercept target)
+                                        //  0.0 = pure pursuit (point directly at target, tail-chase)
+                                        // -0.5 = lag pursuit (fall behind target's path)
+        vel_msg.twist.linear.x = (K_pursuit * vt_perp_E) + (vd_parallel_mag * u_E); // m/s East
+        vel_msg.twist.linear.y = (K_pursuit * vt_perp_N) + (vd_parallel_mag * u_N); // m/s North
+        vel_msg.twist.linear.z = (K_pursuit * vt_perp_U) + (vd_parallel_mag * u_U); // m/s Up
+    } else { // Missing track, stay still
+        vel_msg.twist.linear.x = 0.0;
+        vel_msg.twist.linear.y = 0.0;
+        vel_msg.twist.linear.z = 0.0;
+    }
+    // Computed yaw rate for alignment
+    const double Kp_yaw = 1.5;
+    double heading_error = normalize_heading(std::atan2(vel_msg.twist.linear.y, vel_msg.twist.linear.x) - ((M_PI / 2.0) - (heading_ * M_PI / 180.0)));
+    vel_msg.twist.angular.z = Kp_yaw * heading_error; // rad/s Yaw rate
+    setpoint_vel_pub_->publish(vel_msg);
+}
+void ArdupilotGuided::acc_ref_test()
+{
+    auto accel_msg = geometry_msgs::msg::Vector3Stamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Vector3.html
+    accel_msg.header.stamp = this->get_clock()->now();
+    accel_msg.header.frame_id = "map"; // World frame, with automatic yaw alignment
+    accel_msg.vector.x = 0.0; // m/s^2 East
+    accel_msg.vector.y = 1.5; // m/s^2 North
+    accel_msg.vector.z = 0.0; // m/s^2 Up
+    setpoint_accel_pub_->publish(accel_msg);
+}
+void ArdupilotGuided::acc_ref_proportional_navigation()
+{
+    auto accel_msg = geometry_msgs::msg::Vector3Stamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Vector3.html
+    accel_msg.header.stamp = this->get_clock()->now();
+    accel_msg.header.frame_id = "map"; // World frame, with automatic yaw alignment
+    if (!std::isnan(desired_bearing_rad_) && !std::isnan(desired_elevation_rad_) && !std::isnan(closing_distance_) &&
+        !std::isnan(target_vn_) && !std::isnan(target_ve_) && !std::isnan(target_vd_)) {
+
+        // Calculate ENU error vector
+        double r_E = closing_distance_ * std::sin(desired_bearing_rad_);
+        double r_N = closing_distance_ * std::cos(desired_bearing_rad_);
+        double r_U = closing_distance_ * std::tan(desired_elevation_rad_);
+        double distance_3d = std::max(0.1, std::hypot(closing_distance_, r_U)); // Prevent divide-by-zero
+
+        // Unit LOS Vector in ENU
+        double u_E = r_E / distance_3d;
+        double u_N = r_N / distance_3d;
+        double u_U = r_U / distance_3d;
+
+        // Relative ENU Velocity (target - own)
+        double vrel_E = target_ve_ - ve_;
+        double vrel_N = target_vn_ - vn_;
+        double vrel_U = -target_vd_ - vu_;
+
+        // Closing velocity (Vc = -(r dot vrel) / |r|)
+        double r_dot_vrel = (r_E * vrel_E) + (r_N * vrel_N) + (r_U * vrel_U);
+        double Vc = -r_dot_vrel / distance_3d;
+
+        if (Vc > 0) { // Target is closing
+            // LOS angular rate vector (omega = (r x vrel) / |r|^2)
+            double r_sq = distance_3d * distance_3d;
+            double omega_E = (r_N * vrel_U - r_U * vrel_N) / r_sq;
+            double omega_N = (r_U * vrel_E - r_E * vrel_U) / r_sq;
+            double omega_U = (r_E * vrel_N - r_N * vrel_E) / r_sq;
+
+            // PN steering acceleration (HORIZONTAL ONLY)
+            const double N_gain = 3.0;
+            double a_pn_E = N_gain * Vc * (omega_N * u_U - omega_U * u_N);
+            double a_pn_N = N_gain * Vc * (omega_U * u_E - omega_E * u_U);
+
+            // Distance-based desired closing speed (3m/s if closer than 5m and up to 10m/s if further than 50m)
+            double desired_Vc = 3.0 + std::clamp((closing_distance_ - 5.0) / 50.0, 0.0, 1.0) * 7.0;
+            // Catch-Up acceleration (HORIZONTAL ONLY)
+            double a_fwd_mag = std::clamp(0.5 * (desired_Vc - Vc), -2.0, 3.0);
+            accel_msg.vector.x = a_pn_E + (a_fwd_mag * u_E);
+            accel_msg.vector.y = a_pn_N + (a_fwd_mag * u_N);
+
+        } else { // Target is opening, just thrust in its direction (HORIZONTAL ONLY)
+            accel_msg.vector.x = u_E * 2.0;
+            accel_msg.vector.y = u_N * 2.0;
+        }
+
+        // Account for ArduPilot attitude control limits
+        constexpr double ANGLE_MAX_CDEG = 3000.0; // Note: matches param ANGLE_MAX, ensure WPNAV_ACCEL is set to 500
+        const double MAX_HORIZ_ACCEL = 9.81 * std::tan((ANGLE_MAX_CDEG / 100.0) * (M_PI / 180.0));
+        double a_horiz_mag = std::hypot(accel_msg.vector.x, accel_msg.vector.y);
+        if (a_horiz_mag > MAX_HORIZ_ACCEL) {
+            double scale = MAX_HORIZ_ACCEL / a_horiz_mag;
+            accel_msg.vector.x *= scale;
+            accel_msg.vector.y *= scale;
+        }
+
+        // Decoupled z-axis PD altitude controller (clamped to bounds)
+        const double Kp_Z = 1.0;
+        const double Kd_Z = 1.5;
+        accel_msg.vector.z = (Kp_Z * r_U) + (Kd_Z * vrel_U);
+        accel_msg.vector.z = std::clamp(accel_msg.vector.z, -1.5, 1.5);
+
+    } else { // Missing track, break
+        const double K_brake = 1.0; // Braking gain (1.0 means try to stop in ~1 second)
+        accel_msg.vector.x = -K_brake * ve_;
+        accel_msg.vector.y = -K_brake * vn_;
+        accel_msg.vector.z = -K_brake * vu_;
+        double brake_mag = std::hypot(accel_msg.vector.x, accel_msg.vector.y);
+        const double MAX_BRAKE_ACCEL = 3.0; // Clamp horizontal braking deceleration
+        if (brake_mag > MAX_BRAKE_ACCEL) {
+            double scale = MAX_BRAKE_ACCEL / brake_mag;
+            accel_msg.vector.x *= scale;
+            accel_msg.vector.y *= scale;
+        }
+        accel_msg.vector.z = std::clamp(accel_msg.vector.z, -1.0, 1.0); // Limit vertical deceleration
+    }
+    setpoint_accel_pub_->publish(accel_msg);
 }
 
 int main(int argc, char *argv[])

--- a/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp
@@ -102,8 +102,8 @@ ArdupilotGuided::ArdupilotGuided() : Node("ardupilot_guided"),
 
     // Controllers map
     controller_map_["vel-test"] = std::bind(&ArdupilotGuided::vel_ref_test, this);
-    controller_map_["vel-lp"] = std::bind(&ArdupilotGuided::vel_ref_lead_pursuit, this);
     controller_map_["acc-test"] = std::bind(&ArdupilotGuided::acc_ref_test, this);
+    controller_map_["vel-lp"] = std::bind(&ArdupilotGuided::vel_ref_lead_pursuit, this);
     controller_map_["acc-pn"] = std::bind(&ArdupilotGuided::acc_ref_proportional_navigation, this);
 }
 

--- a/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp
@@ -43,6 +43,7 @@ ArdupilotGuided::ArdupilotGuided() : Node("ardupilot_guided"),
     qos_profile_pub.durability(rclcpp::DurabilityPolicy::TransientLocal);  // Or rclcpp::DurabilityPolicy::Volatile
     setpoint_accel_pub_= this->create_publisher<Vector3Stamped>("/mavros/setpoint_accel/accel", qos_profile_pub);
     setpoint_vel_pub_= this->create_publisher<TwistStamped>("/mavros/setpoint_velocity/cmd_vel", qos_profile_pub);
+    setpoint_raw_att_pub_ = this->create_publisher<AttitudeTarget>("/mavros/setpoint_raw/attitude", qos_profile_pub);
 
     // Create callback groups (Reentrant or MutuallyExclusive)
     callback_group_timer_ = this->create_callback_group(rclcpp::CallbackGroupType::Reentrant); // Timed callbacks in parallel
@@ -101,8 +102,11 @@ ArdupilotGuided::ArdupilotGuided() : Node("ardupilot_guided"),
         std::bind(&ArdupilotGuided::kiss_odometry_callback, this, std::placeholders::_1), subscriber_options);
 
     // Controllers map
+    // Examples
+    controller_map_["att-test"] = std::bind(&ArdupilotGuided::att_ref_test, this);
     controller_map_["vel-test"] = std::bind(&ArdupilotGuided::vel_ref_test, this);
     controller_map_["acc-test"] = std::bind(&ArdupilotGuided::acc_ref_test, this);
+    // Custom controllers
     controller_map_["vel-lp"] = std::bind(&ArdupilotGuided::vel_ref_lead_pursuit, this);
     controller_map_["acc-pn"] = std::bind(&ArdupilotGuided::acc_ref_proportional_navigation, this);
 }
@@ -345,6 +349,23 @@ double ArdupilotGuided::normalize_heading(double angle_rad) {
 }
 
 // Controllers (reference generators)
+void ArdupilotGuided::att_ref_test()
+{
+    auto att_msg = mavros_msgs::msg::AttitudeTarget(); // https://docs.ros.org/en/noetic/api/mavros_msgs/html/msg/AttitudeTarget.html
+    att_msg.header.stamp = this->get_clock()->now();
+    att_msg.header.frame_id = "map"; // World frame
+    double pitch_rad = 5.0 * M_PI / 180.0; // Positive pitch to move forward (any duration)
+    att_msg.orientation.w = std::cos(pitch_rad / 2.0);
+    att_msg.orientation.x = 0.0;
+    att_msg.orientation.y = std::sin(pitch_rad / 2.0);
+    att_msg.orientation.z = 0.0;
+    att_msg.thrust = 0.5; // Normalized scalar between 0.0 (zero thrust) and 1.0 (max thrust)
+    // Ignore roll/pitch/yaw rates
+    att_msg.type_mask = mavros_msgs::msg::AttitudeTarget::IGNORE_ROLL_RATE |
+                        mavros_msgs::msg::AttitudeTarget::IGNORE_PITCH_RATE |
+                        mavros_msgs::msg::AttitudeTarget::IGNORE_YAW_RATE;
+    setpoint_raw_att_pub_->publish(att_msg);
+}
 void ArdupilotGuided::vel_ref_test()
 {
     auto vel_msg = geometry_msgs::msg::TwistStamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Twist.html
@@ -353,8 +374,22 @@ void ArdupilotGuided::vel_ref_test()
     vel_msg.twist.linear.x = 0.0; // m/s East
     vel_msg.twist.linear.y = 5.0; // m/s North
     vel_msg.twist.linear.z = 0.0; // m/s Up
+    // Computed yaw rate for alignment
+    const double Kp_yaw = 1.5;
+    double heading_error = normalize_heading(std::atan2(vel_msg.twist.linear.y, vel_msg.twist.linear.x) - ((M_PI / 2.0) - (heading_ * M_PI / 180.0)));
+    vel_msg.twist.angular.z = Kp_yaw * heading_error; // rad/s Yaw rate
     setpoint_vel_pub_->publish(vel_msg);
     // Alternatively, use the unstamped topic: ros2 topic pub --rate 10 --times 50 /mavros/setpoint_velocity/cmd_vel_unstamped geometry_msgs/msg/Twist '{linear: {x: 2.0, y: 0.0, z: 0.0}}'
+}
+void ArdupilotGuided::acc_ref_test()
+{
+    auto accel_msg = geometry_msgs::msg::Vector3Stamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Vector3.html
+    accel_msg.header.stamp = this->get_clock()->now();
+    accel_msg.header.frame_id = "map"; // World frame, with automatic yaw alignment
+    accel_msg.vector.x = 0.0; // m/s^2 East
+    accel_msg.vector.y = 1.5; // m/s^2 North
+    accel_msg.vector.z = 0.0; // m/s^2 Up
+    setpoint_accel_pub_->publish(accel_msg);
 }
 void ArdupilotGuided::vel_ref_lead_pursuit()
 {
@@ -393,16 +428,6 @@ void ArdupilotGuided::vel_ref_lead_pursuit()
     double heading_error = normalize_heading(std::atan2(vel_msg.twist.linear.y, vel_msg.twist.linear.x) - ((M_PI / 2.0) - (heading_ * M_PI / 180.0)));
     vel_msg.twist.angular.z = Kp_yaw * heading_error; // rad/s Yaw rate
     setpoint_vel_pub_->publish(vel_msg);
-}
-void ArdupilotGuided::acc_ref_test()
-{
-    auto accel_msg = geometry_msgs::msg::Vector3Stamped(); // https://docs.ros.org/en/noetic/api/geometry_msgs/html/msg/Vector3.html
-    accel_msg.header.stamp = this->get_clock()->now();
-    accel_msg.header.frame_id = "map"; // World frame, with automatic yaw alignment
-    accel_msg.vector.x = 0.0; // m/s^2 East
-    accel_msg.vector.y = 1.5; // m/s^2 North
-    accel_msg.vector.z = 0.0; // m/s^2 Up
-    setpoint_accel_pub_->publish(accel_msg);
 }
 void ArdupilotGuided::acc_ref_proportional_navigation()
 {

--- a/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.hpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.hpp
@@ -33,6 +33,7 @@
 #include <geometry_msgs/msg/twist_stamped.hpp>
 
 #include <mavros_msgs/msg/vfr_hud.hpp>
+#include <mavros_msgs/msg/attitude_target.hpp>
 
 #include <nav_msgs/msg/odometry.hpp>
 
@@ -114,6 +115,7 @@ private:
     // MAVROS publishers
     rclcpp::Publisher<Vector3Stamped>::SharedPtr setpoint_accel_pub_;
     rclcpp::Publisher<TwistStamped>::SharedPtr setpoint_vel_pub_;
+    rclcpp::Publisher<AttitudeTarget>::SharedPtr setpoint_raw_att_pub_;
 
     // Callbacks for timers
     void ardupilot_interface_printout_callback();
@@ -141,9 +143,10 @@ private:
     using ControllerFunction = std::function<void()>;
     std::unordered_map<std::string, ControllerFunction> controller_map_;
     ControllerFunction active_controller_func_;
+    void att_ref_test();
     void vel_ref_test();
-    void vel_ref_lead_pursuit();
     void acc_ref_test();
+    void vel_ref_lead_pursuit();
     void acc_ref_proportional_navigation();
 };
 

--- a/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.hpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.hpp
@@ -13,6 +13,8 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
+#include <unordered_map>
+#include <functional>
 
 #include <rclcpp/clock.hpp>
 #include <rclcpp/parameter.hpp>
@@ -59,7 +61,8 @@ private:
     const GeographicLib::Geodesic& geod = GeographicLib::Geodesic::WGS84();
 
     // Node variables
-    std::atomic<int> offboard_flag_;
+    bool offboard_active_;
+    std::string active_controller_name_;
     int offboard_loop_frequency;
     std::atomic<int> offboard_loop_count_;
     std::atomic<int> last_offboard_loop_count_;
@@ -133,6 +136,15 @@ private:
 
     // Utility
     double normalize_heading(double angle_rad);
+
+    // Controller map and controllers
+    using ControllerFunction = std::function<void()>;
+    std::unordered_map<std::string, ControllerFunction> controller_map_;
+    ControllerFunction active_controller_func_;
+    void vel_ref_test();
+    void vel_ref_lead_pursuit();
+    void acc_ref_test();
+    void acc_ref_proportional_navigation();
 };
 
 #endif // OFFBOARD_CONTROL__ARDUPILOT_GUIDED_HPP_

--- a/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp
@@ -103,9 +103,11 @@ PX4Offboard::PX4Offboard() : Node("px4_offboard"),
         std::bind(&PX4Offboard::kiss_odometry_callback, this, std::placeholders::_1), subscriber_options);
 
     // Controllers map
+    // Examples
     controller_map_["att-test"] = std::bind(&PX4Offboard::att_ref_test, this, std::placeholders::_1);
     controller_map_["ctbr-test"] = std::bind(&PX4Offboard::ctbr_ref_test, this, std::placeholders::_1);
     controller_map_["traj-test"] = std::bind(&PX4Offboard::traj_ref_test, this, std::placeholders::_1);
+    // Custom controllers
     controller_map_["traj-prv"] = std::bind(&PX4Offboard::traj_ref_predictive_rendezvous, this, std::placeholders::_1);
 }
 
@@ -349,14 +351,14 @@ void PX4Offboard::att_ref_test(OffboardControlMode& mode)
     VehicleAttitudeSetpoint attitude_ref;
     attitude_ref.timestamp = mode.timestamp;
     if (vehicle_type_ == 1) { // ROTARY_WING
-        double pitch_rad = -5.0 * M_PI / 180.0; // Pitch to move forward (any duration, drops some altitude)
+        double pitch_rad = -5.0 * M_PI / 180.0; // Negative pitch to move forward (any duration, drops some altitude)
         attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
         attitude_ref.q_d[1] = 0;                    // x
         attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
         attitude_ref.q_d[3] = 0;                    // z
         attitude_ref.thrust_body = {0.0, 0.0, -0.72};
     } else if (vehicle_type_ == 2) { // FIXED_WING
-        double pitch_rad = -30.0 * M_PI / 180.0; // Pitch to dive
+        double pitch_rad = -30.0 * M_PI / 180.0; // Negative pitch to dive
         attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
         attitude_ref.q_d[1] = 0;                    // x
         attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y

--- a/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp
@@ -1,7 +1,7 @@
 #include "px4_offboard.hpp"
 
 PX4Offboard::PX4Offboard() : Node("px4_offboard"), 
-    own_id_(-1), offboard_flag_(0),
+    own_id_(-1), offboard_active_(false), active_controller_name_(""), active_controller_func_(nullptr),
     offboard_loop_frequency(50), offboard_loop_count_(0), last_offboard_loop_count_(0),
     lat_(NAN), lon_(NAN), alt_(NAN), alt_ellipsoid_(NAN),
     xy_valid_(false), z_valid_(false), v_xy_valid_(false), v_z_valid_(false), xy_global_(false), z_global_(false),
@@ -98,6 +98,15 @@ PX4Offboard::PX4Offboard() : Node("px4_offboard"),
     kiss_odometry_sub_ = this->create_subscription<nav_msgs::msg::Odometry>(
         "/kiss/odometry", qos_profile_sub, // 10Hz
         std::bind(&PX4Offboard::kiss_odometry_callback, this, std::placeholders::_1), subscriber_options);
+
+    // Controllers map
+    controller_map_["att-test-quad"] = std::bind(&PX4Offboard::att_ref_test_quad, this, std::placeholders::_1);
+    controller_map_["att-test-vtol"] = std::bind(&PX4Offboard::att_ref_test_vtol, this, std::placeholders::_1);
+    controller_map_["ctbr-test-quad"] = std::bind(&PX4Offboard::ctbr_ref_test_quad, this, std::placeholders::_1);
+    controller_map_["ctbr-test-vtol"] = std::bind(&PX4Offboard::ctbr_ref_test_vtol, this, std::placeholders::_1);
+    controller_map_["traj-test-quad"] = std::bind(&PX4Offboard::traj_ref_test_quad, this, std::placeholders::_1);
+    controller_map_["traj-test-vtol"] = std::bind(&PX4Offboard::traj_ref_test_vtol, this, std::placeholders::_1);
+    controller_map_["traj-pred-rv"] = std::bind(&PX4Offboard::traj_ref_predictive_rendezvous, this, std::placeholders::_1);
 }
 
 // Callbacks for subscribers (reentrant group)
@@ -150,7 +159,21 @@ void PX4Offboard::airspeed_callback(const AirspeedValidated::SharedPtr msg)
 void PX4Offboard::offboard_flag_callaback(const autopilot_interface_msgs::msg::OffboardFlag::SharedPtr msg)
 {
     std::unique_lock<std::shared_mutex> lock(node_data_mutex_); // Use unique_lock for data writes
-    offboard_flag_ = msg->offboard_flag;
+    offboard_active_ = msg->is_active;
+    if (offboard_active_) {
+        if (active_controller_name_ != msg->controller_name) { // Only perform the map lookup if the requested controller has changed
+            active_controller_name_ = msg->controller_name;
+            auto it = controller_map_.find(active_controller_name_);
+            if (it != controller_map_.end()) {
+                active_controller_func_ = it->second; // Cache the controller function
+            } else {
+                active_controller_func_ = nullptr; // Failsafe
+            }
+        }
+    } else { // Clean up when offboard flag is inactive
+        active_controller_name_ = "";
+        active_controller_func_ = nullptr;
+    }
 }
 void PX4Offboard::ground_tracks_callback(const ground_system_msgs::msg::SwarmObs::SharedPtr msg)
 {
@@ -241,11 +264,13 @@ void PX4Offboard::px4_interface_printout_callback()
     RCLCPP_INFO(get_logger(),
                 "\n  Current node time: %.2f seconds\n"
                 "  KISS pos: %.2f %.2f %.2f\n"
-                "  Offboard flag:\t%d\n"
+                "  Offboard active:\t%s\n"
+                "  Controller:\t%s\n"
                 "  Offboard loop rate:\t%.2f Hz",
                 this->get_clock()->now().seconds(),
                 kiss_position_[0], kiss_position_[1], kiss_position_[2],
-                offboard_flag_.load(),
+                offboard_active_ ? "true" : "false",
+                offboard_active_ ? active_controller_name_.c_str() : "None",
                 actual_rate
             );
     std::stringstream ss;
@@ -290,120 +315,134 @@ void PX4Offboard::px4_interface_printout_callback()
 void PX4Offboard::offboard_loop_callback()
 {
     offboard_loop_count_++; // Counter to monitor the rate of the offboard loop (no lock, atomic variable)
-
     std::shared_lock<std::shared_mutex> lock(node_data_mutex_); // Use shared_lock for data reads
-
-    uint64_t current_time_us = this->get_clock()->now().nanoseconds() / 1000;  // Convert to microseconds
-    OffboardControlMode offboard_mode;
-    offboard_mode.timestamp = current_time_us;
-    if (offboard_flag_ == 0) {
-        return; // Do not publish anything else if not in an OFFBOARD state
-    // TODO: implement custom offboard control logic here
-    // https://docs.px4.io/v1.17/en/flight_modes/offboard.html
-    } else if (offboard_flag_ == 1) { // Quad attitude reference
-        offboard_mode.attitude = true;
-        VehicleAttitudeSetpoint attitude_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleAttitudeSetpoint.msg
-        attitude_ref.timestamp = current_time_us;
-        double pitch_rad = -5.0 * M_PI / 180.0; // Pitch to move forward (any duration, drops some altitude)
-        attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
-        attitude_ref.q_d[1] = 0;                    // x
-        attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
-        attitude_ref.q_d[3] = 0;                    // z
-        attitude_ref.thrust_body = {0.0, 0.0, -0.72};
-        attitude_ref_pub_->publish(attitude_ref);
-    } else if (offboard_flag_ == 2) { // VTOL attitude reference
-        offboard_mode.attitude = true;
-        VehicleAttitudeSetpoint attitude_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleAttitudeSetpoint.msg
-        attitude_ref.timestamp = current_time_us;
-        double pitch_rad = -30.0 * M_PI / 180.0; // Pitch to dive
-        attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
-        attitude_ref.q_d[1] = 0;                    // x
-        attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
-        attitude_ref.q_d[3] = 0;                    // z
-        attitude_ref.thrust_body = {0.15, 0.0, 0.0};
-        attitude_ref_pub_->publish(attitude_ref);
-    } else if (offboard_flag_ == 3) { // Quad rates reference
-        offboard_mode.body_rate = true;
-        VehicleRatesSetpoint rates_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleRatesSetpoint.msg
-        rates_ref.timestamp = current_time_us;
-        rates_ref.roll= 0.0;
-        rates_ref.pitch = 0.0;
-        rates_ref.yaw = 1.0; // Spin on itself (any duration)
-        rates_ref.thrust_body = {0.0, 0.0, -0.72};
-        rates_ref_pub_->publish(rates_ref);
-    } else if (offboard_flag_ == 4) { // VTOL rates reference
-        offboard_mode.body_rate = true;
-        VehicleRatesSetpoint rates_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleRatesSetpoint.msg
-        rates_ref.timestamp = current_time_us;
-        rates_ref.roll= 4.0; // Roll (2sec maneuver 1 roll, 3sec double roll)
-        rates_ref.pitch = 0.0;
-        rates_ref.thrust_body = {0.39, 0.0, 0.0};
-        rates_ref_pub_->publish(rates_ref);
-    } else if (offboard_flag_ == 5) { // Quad trajectory (position) reference
-        TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
-        trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
-        trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
-        trajectory_ref.timestamp = current_time_us;
-        offboard_mode.position = true;
-        trajectory_ref.position = {0.0, 0.0, -50.0}; // Home point
-        trajectory_ref.yaw = -3.14; // [-PI:PI]
-        ///////////////////////////////////////////////////////////////////////
-        // Predictive rendez-vous /////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        if (!std::isnan(traj_ref_east_) && !std::isnan(traj_ref_north_) && !std::isnan(traj_ref_up_)) {
-            double dt = std::clamp((this->get_clock()->now() - last_track_time_).seconds(), 0.0, 2.0);
-            double current_north = traj_ref_north_ + (target_vn_ * dt);
-            double current_east  = traj_ref_east_  + (target_ve_ * dt);
-            double current_down  = -traj_ref_up_   + (target_vd_ * dt);
-            trajectory_ref.position = {current_north, current_east, current_down};
-            double d_north = current_north - x_;
-            double d_east  = current_east - y_;
-            trajectory_ref.yaw = std::atan2(d_east, d_north); // [-PI:PI]
-            if (!std::isnan(target_vn_) && !std::isnan(target_ve_) && !std::isnan(target_vd_)) {
-                offboard_mode.velocity = true; // Enable velocity feedforward
-                trajectory_ref.velocity = {target_vn_, target_ve_, target_vd_};
-                double dist_sq = (d_north * d_north) + (d_east * d_east);
-                if (dist_sq > 1.0) {
-                    double vrel_n = target_vn_ - vx_;
-                    double vrel_e = target_ve_ - vy_;
-                    trajectory_ref.yawspeed = (d_north * vrel_e - d_east * vrel_n) / dist_sq;
-                } else {
-                    trajectory_ref.yawspeed = 0.0;
-                }
-            } else {
-                trajectory_ref.velocity = {NAN, NAN, NAN};
-                trajectory_ref.yawspeed = NAN;
-            }
-        } else { // Missing track, stay still
-            offboard_mode.position = false;
-            trajectory_ref.position = {NAN, NAN, NAN}; ;
-            trajectory_ref.yaw = NAN;
-            offboard_mode.velocity = true;
-            trajectory_ref.velocity = {0.0, 0.0, 0.0};
-            trajectory_ref.yawspeed = 0.0;
+    if (!offboard_active_) {
+        return; // Do not publish anything else if not in OFFBOARD state
+    }
+    if (active_controller_func_ != nullptr) {
+        OffboardControlMode offboard_mode;
+        offboard_mode.timestamp = this->get_clock()->now().nanoseconds() / 1000; // Convert to microseconds
+        active_controller_func_(offboard_mode); // Execute the cached controller, passing the mode by reference (to modify it and copy its timestamp)
+        if (offboard_loop_count_ % std::max(1, (offboard_loop_frequency / 10)) == 0) {
+            offboard_mode_pub_->publish(offboard_mode); // The OffboardControlMode should run at at least 2Hz (~10 in this implementation)
         }
-        ///////////////////////////////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        ///////////////////////////////////////////////////////////////////////
-        // offboard_mode.acceleration = true; // Enable acceleration feedforward
-        // trajectory_ref.acceleration = {0.0, 0.0, -5.0};
-        trajectory_ref_pub_->publish(trajectory_ref);
-    } else if (offboard_flag_ == 6) { // VTOL trajectory (velocity) reference
-        TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
-        trajectory_ref.position = {NAN, NAN, NAN}; // Unused
-        trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
-        trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
-        trajectory_ref.timestamp = current_time_us;
-        offboard_mode.velocity = true;
-        trajectory_ref.velocity = {20.0, 0.0, 0.0};
-        trajectory_ref_pub_->publish(trajectory_ref);
     } else {
-        RCLCPP_WARN(get_logger(), "Unexpected offboard_flag value: %d", offboard_flag_.load());
+        RCLCPP_WARN(get_logger(), "Unknown controller requested: '%s', no reference will be published", active_controller_name_.c_str());
     }
+}
 
-    if (offboard_loop_count_ % std::max(1, (offboard_loop_frequency / 10)) == 0) {
-        offboard_mode_pub_->publish(offboard_mode); // The OffboardControlMode should run at at least 2Hz (~10 in this implementation)
+// Controllers (reference generators)
+void PX4Offboard::att_ref_test_quad(OffboardControlMode& mode)
+{
+    mode.attitude = true;
+    VehicleAttitudeSetpoint attitude_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleAttitudeSetpoint.msg
+    attitude_ref.timestamp = mode.timestamp;
+    double pitch_rad = -5.0 * M_PI / 180.0; // Pitch to move forward (any duration, drops some altitude)
+    attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
+    attitude_ref.q_d[1] = 0;                    // x
+    attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
+    attitude_ref.q_d[3] = 0;                    // z
+    attitude_ref.thrust_body = {0.0, 0.0, -0.72};
+    attitude_ref_pub_->publish(attitude_ref);
+}
+void PX4Offboard::att_ref_test_vtol(OffboardControlMode& mode)
+{
+    mode.attitude = true;
+    VehicleAttitudeSetpoint attitude_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleAttitudeSetpoint.msg
+    attitude_ref.timestamp = mode.timestamp;
+    double pitch_rad = -30.0 * M_PI / 180.0; // Pitch to dive
+    attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
+    attitude_ref.q_d[1] = 0;                    // x
+    attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
+    attitude_ref.q_d[3] = 0;                    // z
+    attitude_ref.thrust_body = {0.15, 0.0, 0.0};
+    attitude_ref_pub_->publish(attitude_ref);
+}
+void PX4Offboard::ctbr_ref_test_quad(OffboardControlMode& mode)
+{
+    mode.body_rate = true;
+    VehicleRatesSetpoint rates_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleRatesSetpoint.msg
+    rates_ref.timestamp = mode.timestamp;
+    rates_ref.roll= 0.0;
+    rates_ref.pitch = 0.0;
+    rates_ref.yaw = 1.0; // Spin on itself (any duration)
+    rates_ref.thrust_body = {0.0, 0.0, -0.72};
+    rates_ref_pub_->publish(rates_ref);
+}
+void PX4Offboard::ctbr_ref_test_vtol(OffboardControlMode& mode)
+{
+    mode.body_rate = true;
+    VehicleRatesSetpoint rates_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleRatesSetpoint.msg
+    rates_ref.timestamp = mode.timestamp;
+    rates_ref.roll= 4.0; // Roll (2sec maneuver 1 roll, 3sec double roll)
+    rates_ref.pitch = 0.0;
+    rates_ref.thrust_body = {0.39, 0.0, 0.0};
+    rates_ref_pub_->publish(rates_ref);
+}
+void PX4Offboard::traj_ref_test_quad(OffboardControlMode& mode)
+{
+    mode.position = true;
+    // offboard_mode.acceleration = true; // Enable acceleration feedforward
+    TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
+    trajectory_ref.timestamp = mode.timestamp;
+    trajectory_ref.position = {0.0, 0.0, -50.0}; // Home point
+    trajectory_ref.velocity = {NAN, NAN, NAN}; // Unused
+    trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
+    trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
+    trajectory_ref.yaw = -3.14; // [-PI:PI]
+    trajectory_ref_pub_->publish(trajectory_ref);
+}
+void PX4Offboard::traj_ref_test_vtol(OffboardControlMode& mode)
+{
+    mode.velocity = true;
+    TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
+    trajectory_ref.timestamp = mode.timestamp;
+    trajectory_ref.position = {NAN, NAN, NAN}; // Unused
+    trajectory_ref.velocity = {20.0, 0.0, 0.0};
+    trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
+    trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
+    trajectory_ref_pub_->publish(trajectory_ref);
+}
+void PX4Offboard::traj_ref_predictive_rendezvous(OffboardControlMode& mode)
+{
+    mode.position = true;
+    TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
+    trajectory_ref.timestamp = mode.timestamp;
+    trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
+    trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
+    if (!std::isnan(traj_ref_east_) && !std::isnan(traj_ref_north_) && !std::isnan(traj_ref_up_)) {
+        double dt = std::clamp((this->get_clock()->now() - last_track_time_).seconds(), 0.0, 2.0);
+        double current_north = traj_ref_north_ + (target_vn_ * dt);
+        double current_east  = traj_ref_east_  + (target_ve_ * dt);
+        double current_down  = -traj_ref_up_   + (target_vd_ * dt);
+        trajectory_ref.position = {current_north, current_east, current_down};
+        double d_north = current_north - x_;
+        double d_east  = current_east - y_;
+        trajectory_ref.yaw = std::atan2(d_east, d_north); // [-PI:PI]
+        if (!std::isnan(target_vn_) && !std::isnan(target_ve_) && !std::isnan(target_vd_)) {
+            mode.velocity = true; // Enable velocity feedforward
+            trajectory_ref.velocity = {target_vn_, target_ve_, target_vd_};
+            double dist_sq = (d_north * d_north) + (d_east * d_east);
+            if (dist_sq > 1.0) {
+                double vrel_n = target_vn_ - vx_;
+                double vrel_e = target_ve_ - vy_;
+                trajectory_ref.yawspeed = (d_north * vrel_e - d_east * vrel_n) / dist_sq;
+            } else {
+                trajectory_ref.yawspeed = 0.0;
+            }
+        } else {
+            trajectory_ref.velocity = {NAN, NAN, NAN};
+            trajectory_ref.yawspeed = NAN;
+        }
+    } else { // Missing track, stay still
+        mode.position = false;
+        trajectory_ref.position = {NAN, NAN, NAN}; ;
+        trajectory_ref.yaw = NAN;
+        mode.velocity = true;
+        trajectory_ref.velocity = {0.0, 0.0, 0.0};
+        trajectory_ref.yawspeed = 0.0;
     }
+    trajectory_ref_pub_->publish(trajectory_ref);
 }
 
 int main(int argc, char *argv[])

--- a/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp
@@ -385,7 +385,7 @@ void PX4Offboard::traj_ref_test_quad(OffboardControlMode& mode)
     // offboard_mode.acceleration = true; // Enable acceleration feedforward
     TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
     trajectory_ref.timestamp = mode.timestamp;
-    trajectory_ref.position = {0.0, 0.0, -50.0}; // Home point
+    trajectory_ref.position = {0.0, 0.0, -50.0}; // 50m above the home point
     trajectory_ref.velocity = {NAN, NAN, NAN}; // Unused
     trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
     trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused

--- a/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.cpp
@@ -6,7 +6,7 @@ PX4Offboard::PX4Offboard() : Node("px4_offboard"),
     lat_(NAN), lon_(NAN), alt_(NAN), alt_ellipsoid_(NAN),
     xy_valid_(false), z_valid_(false), v_xy_valid_(false), v_z_valid_(false), xy_global_(false), z_global_(false),
     x_(NAN), y_(NAN), z_(NAN), heading_(NAN), vx_(NAN), vy_(NAN), vz_(NAN), ref_lat_(NAN), ref_lon_(NAN), ref_alt_(NAN),
-    pose_frame_(-1), velocity_frame_(-1), true_airspeed_m_s_(NAN),
+    pose_frame_(-1), velocity_frame_(-1), true_airspeed_m_s_(NAN), vehicle_type_(-1),
     ground_tracks_(nullptr), yolo_detections_(nullptr),
     traj_ref_east_(NAN), traj_ref_north_(NAN), traj_ref_up_(NAN),
     target_vn_(NAN), target_ve_(NAN), target_vd_(NAN)
@@ -82,6 +82,9 @@ PX4Offboard::PX4Offboard() : Node("px4_offboard"),
     airspeed_validated_sub_ = this->create_subscription<AirspeedValidated>(
         "fmu/out/airspeed_validated_v1", qos_profile_sub, // 10Hz, MESSAGE_VERSION = 1 -> _v1 since 1.17
         std::bind(&PX4Offboard::airspeed_callback, this, std::placeholders::_1), subscriber_options);
+    vehicle_status_sub_ = this->create_subscription<VehicleStatus>(
+        "fmu/out/vehicle_status_v1", qos_profile_sub, // 2Hz, MESSAGE_VERSION = 1 -> _v1 since 1.16
+        std::bind(&PX4Offboard::status_callback, this, std::placeholders::_1), subscriber_options);
 
     // Offboard flag subscriber
     offboard_flag_sub_ = this->create_subscription<autopilot_interface_msgs::msg::OffboardFlag>(
@@ -100,13 +103,10 @@ PX4Offboard::PX4Offboard() : Node("px4_offboard"),
         std::bind(&PX4Offboard::kiss_odometry_callback, this, std::placeholders::_1), subscriber_options);
 
     // Controllers map
-    controller_map_["att-test-quad"] = std::bind(&PX4Offboard::att_ref_test_quad, this, std::placeholders::_1);
-    controller_map_["att-test-vtol"] = std::bind(&PX4Offboard::att_ref_test_vtol, this, std::placeholders::_1);
-    controller_map_["ctbr-test-quad"] = std::bind(&PX4Offboard::ctbr_ref_test_quad, this, std::placeholders::_1);
-    controller_map_["ctbr-test-vtol"] = std::bind(&PX4Offboard::ctbr_ref_test_vtol, this, std::placeholders::_1);
-    controller_map_["traj-test-quad"] = std::bind(&PX4Offboard::traj_ref_test_quad, this, std::placeholders::_1);
-    controller_map_["traj-test-vtol"] = std::bind(&PX4Offboard::traj_ref_test_vtol, this, std::placeholders::_1);
-    controller_map_["traj-pred-rv"] = std::bind(&PX4Offboard::traj_ref_predictive_rendezvous, this, std::placeholders::_1);
+    controller_map_["att-test"] = std::bind(&PX4Offboard::att_ref_test, this, std::placeholders::_1);
+    controller_map_["ctbr-test"] = std::bind(&PX4Offboard::ctbr_ref_test, this, std::placeholders::_1);
+    controller_map_["traj-test"] = std::bind(&PX4Offboard::traj_ref_test, this, std::placeholders::_1);
+    controller_map_["traj-prv"] = std::bind(&PX4Offboard::traj_ref_predictive_rendezvous, this, std::placeholders::_1);
 }
 
 // Callbacks for subscribers (reentrant group)
@@ -155,6 +155,17 @@ void PX4Offboard::airspeed_callback(const AirspeedValidated::SharedPtr msg)
 {
     std::unique_lock<std::shared_mutex> lock(node_data_mutex_); // Use unique_lock for data writes
     true_airspeed_m_s_ = msg->true_airspeed_m_s;
+}
+void PX4Offboard::status_callback(const VehicleStatus::SharedPtr msg)
+{
+    std::unique_lock<std::shared_mutex> lock(node_data_mutex_); // Use unique_lock for data writes
+    // arming_state_ = msg->arming_state; // DISARMED = 1, ARMED = 2
+    vehicle_type_ = msg->vehicle_type; // ROTARY_WING = 1, FIXED_WING = 2 (ROVER = 3)
+    // is_vtol_ = msg->is_vtol; // bool
+    // is_vtol_tailsitter_ = msg->is_vtol_tailsitter; // bool
+    // in_transition_mode_ = msg->in_transition_mode; // bool
+    // in_transition_to_fw_ = msg->in_transition_to_fw; // bool
+    // pre_flight_checks_pass_ = msg->pre_flight_checks_pass; // bool
 }
 void PX4Offboard::offboard_flag_callaback(const autopilot_interface_msgs::msg::OffboardFlag::SharedPtr msg)
 {
@@ -332,79 +343,81 @@ void PX4Offboard::offboard_loop_callback()
 }
 
 // Controllers (reference generators)
-void PX4Offboard::att_ref_test_quad(OffboardControlMode& mode)
+void PX4Offboard::att_ref_test(OffboardControlMode& mode)
 {
     mode.attitude = true;
-    VehicleAttitudeSetpoint attitude_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleAttitudeSetpoint.msg
+    VehicleAttitudeSetpoint attitude_ref;
     attitude_ref.timestamp = mode.timestamp;
-    double pitch_rad = -5.0 * M_PI / 180.0; // Pitch to move forward (any duration, drops some altitude)
-    attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
-    attitude_ref.q_d[1] = 0;                    // x
-    attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
-    attitude_ref.q_d[3] = 0;                    // z
-    attitude_ref.thrust_body = {0.0, 0.0, -0.72};
+    if (vehicle_type_ == 1) { // ROTARY_WING
+        double pitch_rad = -5.0 * M_PI / 180.0; // Pitch to move forward (any duration, drops some altitude)
+        attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
+        attitude_ref.q_d[1] = 0;                    // x
+        attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
+        attitude_ref.q_d[3] = 0;                    // z
+        attitude_ref.thrust_body = {0.0, 0.0, -0.72};
+    } else if (vehicle_type_ == 2) { // FIXED_WING
+        double pitch_rad = -30.0 * M_PI / 180.0; // Pitch to dive
+        attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
+        attitude_ref.q_d[1] = 0;                    // x
+        attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
+        attitude_ref.q_d[3] = 0;                    // z
+        attitude_ref.thrust_body = {0.15, 0.0, 0.0};
+    } else {
+        RCLCPP_WARN(get_logger(), "Unknown vehicle_type_ %d", vehicle_type_);
+        return;
+    }
     attitude_ref_pub_->publish(attitude_ref);
 }
-void PX4Offboard::att_ref_test_vtol(OffboardControlMode& mode)
-{
-    mode.attitude = true;
-    VehicleAttitudeSetpoint attitude_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleAttitudeSetpoint.msg
-    attitude_ref.timestamp = mode.timestamp;
-    double pitch_rad = -30.0 * M_PI / 180.0; // Pitch to dive
-    attitude_ref.q_d[0] = cos(pitch_rad / 2.0); // w
-    attitude_ref.q_d[1] = 0;                    // x
-    attitude_ref.q_d[2] = sin(pitch_rad / 2.0); // y
-    attitude_ref.q_d[3] = 0;                    // z
-    attitude_ref.thrust_body = {0.15, 0.0, 0.0};
-    attitude_ref_pub_->publish(attitude_ref);
-}
-void PX4Offboard::ctbr_ref_test_quad(OffboardControlMode& mode)
+void PX4Offboard::ctbr_ref_test(OffboardControlMode& mode)
 {
     mode.body_rate = true;
     VehicleRatesSetpoint rates_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleRatesSetpoint.msg
     rates_ref.timestamp = mode.timestamp;
-    rates_ref.roll= 0.0;
-    rates_ref.pitch = 0.0;
-    rates_ref.yaw = 1.0; // Spin on itself (any duration)
-    rates_ref.thrust_body = {0.0, 0.0, -0.72};
+    if (vehicle_type_ == 1) { // ROTARY_WING
+        rates_ref.roll= 0.0;
+        rates_ref.pitch = 0.0;
+        rates_ref.yaw = 1.0; // Spin on itself (any duration)
+        rates_ref.thrust_body = {0.0, 0.0, -0.72};
+    } else if (vehicle_type_ == 2) { // FIXED_WING
+        rates_ref.roll= 4.0; // Roll (2sec maneuver 1 roll, 3sec double roll)
+        rates_ref.pitch = 0.0;
+        rates_ref.thrust_body = {0.39, 0.0, 0.0};
+    } else {
+        RCLCPP_WARN(get_logger(), "Unknown vehicle_type_ %d", vehicle_type_);
+        return;
+    }
     rates_ref_pub_->publish(rates_ref);
 }
-void PX4Offboard::ctbr_ref_test_vtol(OffboardControlMode& mode)
+void PX4Offboard::traj_ref_test(OffboardControlMode& mode)
 {
-    mode.body_rate = true;
-    VehicleRatesSetpoint rates_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/VehicleRatesSetpoint.msg
-    rates_ref.timestamp = mode.timestamp;
-    rates_ref.roll= 4.0; // Roll (2sec maneuver 1 roll, 3sec double roll)
-    rates_ref.pitch = 0.0;
-    rates_ref.thrust_body = {0.39, 0.0, 0.0};
-    rates_ref_pub_->publish(rates_ref);
-}
-void PX4Offboard::traj_ref_test_quad(OffboardControlMode& mode)
-{
-    mode.position = true;
-    // offboard_mode.acceleration = true; // Enable acceleration feedforward
     TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
     trajectory_ref.timestamp = mode.timestamp;
-    trajectory_ref.position = {0.0, 0.0, -50.0}; // 50m above the home point
-    trajectory_ref.velocity = {NAN, NAN, NAN}; // Unused
-    trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
-    trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
-    trajectory_ref.yaw = -3.14; // [-PI:PI]
-    trajectory_ref_pub_->publish(trajectory_ref);
-}
-void PX4Offboard::traj_ref_test_vtol(OffboardControlMode& mode)
-{
-    mode.velocity = true;
-    TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
-    trajectory_ref.timestamp = mode.timestamp;
-    trajectory_ref.position = {NAN, NAN, NAN}; // Unused
-    trajectory_ref.velocity = {20.0, 0.0, 0.0};
-    trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
-    trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
+    if (vehicle_type_ == 1) { // ROTARY_WING
+        mode.position = true;
+        // mode.acceleration = true; // Enable acceleration feedforward
+        trajectory_ref.position = {0.0, 0.0, -50.0}; // 50m above the home point
+        trajectory_ref.velocity = {NAN, NAN, NAN}; // Unused
+        trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
+        trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
+        trajectory_ref.yaw = -3.14; // [-PI:PI]
+    } else if (vehicle_type_ == 2) { // FIXED_WING
+        mode.velocity = true;
+        trajectory_ref.position = {NAN, NAN, NAN}; // Unused
+        trajectory_ref.velocity = {20.0, 0.0, 0.0};
+        trajectory_ref.acceleration = {NAN, NAN, NAN}; // Unused
+        trajectory_ref.jerk = {NAN, NAN, NAN}; // Unused
+    } else {
+        RCLCPP_WARN(get_logger(), "Unknown vehicle_type_ %d", vehicle_type_);
+        return;
+    }
     trajectory_ref_pub_->publish(trajectory_ref);
 }
 void PX4Offboard::traj_ref_predictive_rendezvous(OffboardControlMode& mode)
 {
+    if (vehicle_type_ != 1) { // Publish nothing if the vehicle is not ROTARY_WING
+        RCLCPP_WARN(get_logger(), "This controller is only for multicopters");
+        return;
+    }
     mode.position = true;
     TrajectorySetpoint trajectory_ref; // https://github.com/PX4/px4_msgs/blob/release/1.17/msg/TrajectorySetpoint.msg
     trajectory_ref.timestamp = mode.timestamp;

--- a/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.hpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.hpp
@@ -31,6 +31,7 @@
 #include <px4_msgs/msg/vehicle_local_position.hpp>
 #include <px4_msgs/msg/airspeed_validated.hpp>
 #include <px4_msgs/msg/vehicle_odometry.hpp>
+#include <px4_msgs/msg/vehicle_status.hpp>
 
 #include <px4_msgs/msg/offboard_control_mode.hpp>
 #include <px4_msgs/msg/vehicle_attitude_setpoint.hpp>
@@ -78,6 +79,7 @@ private:
     rclcpp::Subscription<VehicleLocalPosition>::SharedPtr vehicle_local_position_sub_;
     rclcpp::Subscription<VehicleOdometry>::SharedPtr vehicle_odometry_sub_;
     rclcpp::Subscription<AirspeedValidated>::SharedPtr airspeed_validated_sub_;
+    rclcpp::Subscription<VehicleStatus>::SharedPtr vehicle_status_sub_;
 
     // Offboard flag subscriber
     rclcpp::Subscription<autopilot_interface_msgs::msg::OffboardFlag>::SharedPtr offboard_flag_sub_;
@@ -98,6 +100,7 @@ private:
     std::array<float, 3> velocity_;
     std::array<float, 3> angular_velocity_;
     double true_airspeed_m_s_;
+    int vehicle_type_;
     std::array<float, 3> kiss_position_;
     std::array<float, 4> kiss_q_;
     ground_system_msgs::msg::SwarmObs::SharedPtr ground_tracks_;
@@ -123,6 +126,7 @@ private:
     void local_position_callback(const VehicleLocalPosition::SharedPtr msg);
     void odometry_callback(const VehicleOdometry::SharedPtr msg);
     void airspeed_callback(const AirspeedValidated::SharedPtr msg);
+    void status_callback(const VehicleStatus::SharedPtr msg);
 
     // Offboard flag call back
     void offboard_flag_callaback(const autopilot_interface_msgs::msg::OffboardFlag::SharedPtr msg);
@@ -136,12 +140,9 @@ private:
     using ControllerFunction = std::function<void(OffboardControlMode&)>;
     std::unordered_map<std::string, ControllerFunction> controller_map_;
     ControllerFunction active_controller_func_;
-    void att_ref_test_quad(OffboardControlMode& mode);
-    void att_ref_test_vtol(OffboardControlMode& mode);
-    void ctbr_ref_test_quad(OffboardControlMode& mode);
-    void ctbr_ref_test_vtol(OffboardControlMode& mode);
-    void traj_ref_test_quad(OffboardControlMode& mode);
-    void traj_ref_test_vtol(OffboardControlMode& mode);
+    void att_ref_test(OffboardControlMode& mode);
+    void ctbr_ref_test(OffboardControlMode& mode);
+    void traj_ref_test(OffboardControlMode& mode);
     void traj_ref_predictive_rendezvous(OffboardControlMode& mode);
 };
 

--- a/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.hpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/px4_offboard.hpp
@@ -13,6 +13,8 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
+#include <unordered_map>
+#include <functional>
 
 #include <rclcpp/clock.hpp>
 #include <rclcpp/parameter.hpp>
@@ -55,7 +57,8 @@ private:
     const GeographicLib::Geodesic& geod = GeographicLib::Geodesic::WGS84();
 
     // Node variables
-    std::atomic<int> offboard_flag_;
+    bool offboard_active_;
+    std::string active_controller_name_;
     int offboard_loop_frequency;
     std::atomic<int> offboard_loop_count_;
     std::atomic<int> last_offboard_loop_count_;
@@ -128,6 +131,18 @@ private:
     void ground_tracks_callback(const ground_system_msgs::msg::SwarmObs::SharedPtr msg);
     void yolo_detections_callback(const vision_msgs::msg::Detection2DArray::SharedPtr msg);
     void kiss_odometry_callback(const nav_msgs::msg::Odometry::SharedPtr msg);
+
+    // Controller map and controllers
+    using ControllerFunction = std::function<void(OffboardControlMode&)>;
+    std::unordered_map<std::string, ControllerFunction> controller_map_;
+    ControllerFunction active_controller_func_;
+    void att_ref_test_quad(OffboardControlMode& mode);
+    void att_ref_test_vtol(OffboardControlMode& mode);
+    void ctbr_ref_test_quad(OffboardControlMode& mode);
+    void ctbr_ref_test_vtol(OffboardControlMode& mode);
+    void traj_ref_test_quad(OffboardControlMode& mode);
+    void traj_ref_test_vtol(OffboardControlMode& mode);
+    void traj_ref_predictive_rendezvous(OffboardControlMode& mode);
 };
 
 #endif // OFFBOARD_CONTROL__PX4_OFFBOARD_HPP_


### PR DESCRIPTION
Change log
- Messages (`autopilot_interface_msgs`): switched integer enum for string `controller_name`
  - **BREAKING** instead of once control loop per reference type, now allows an arbitrary number of controllers 
- Action Servers (`px4/ardupilot_interface.hpp/cpp`): simpler FSM with a single OFFBOARD state
- Dispatchers (`px4/ardupilot_guided.hpp/cpp` / `px4/ardupilot_offboard.hpp/cpp`): zero-overhead C++ hash map dispatcher of the target controller function
- Controllers: now pure, reusable functions; arbitrarily extensible list
- Orchestrators (`mission_node.py` / `dtc_client.cpp`): updated to send human-readable offboard commands
- Documentation: updated `README.md` and `test.yaml`

TODOs

- [x] Ways to control the drones in README (dtc, mission, offboard)
- [x] Add attitude control for ArduPilot GUIDED MODE
- [x] Common controller name across autopilots