### PR TITLE
docs(sim): document waterworld in sim_run WORLD options

### DIFF
--- a/tools_and_docs/sim_run.sh
+++ b/tools_and_docs/sim_run.sh
@@ -18,7 +18,7 @@ GROUND_ID="${GROUND_ID:-101}" # Last byte of the simulation container IP (defaul
 NUM_QUADS="${NUM_QUADS:-1}" # Number of quadcopters (default = 1)
 NUM_VTOLS="${NUM_VTOLS:-0}" # Number of VTOLs (default = 0)
 NUM_TAILS="${NUM_TAILS:-0}" # Number of tailsitters (default = 0)
-WORLD="${WORLD:-impalpable_greyness}" # Options: impalpable_greyness (default), apple_orchard, shibuya_crossing, swiss_town
+WORLD="${WORLD:-impalpable_greyness}" # Options: impalpable_greyness (default), apple_orchard, shibuya_crossing, swiss_town, waterworld
 #
 DEV="${DEV:-false}" # Options: true, false (default)
 HITL="${HITL:-false}" # Options: true, false (default)


### PR DESCRIPTION
## Summary
- Extends the `WORLD=` option comment in `tools_and_docs/sim_run.sh` to include `waterworld`, matching README and the existing `waterworld.sdf` sim asset.
- Comment-only; no runtime default change (`impalpable_greyness` remains default).

## Why
README documents five worlds including dynamic `waterworld` (wave plugin). The script header omitted it, so grepping env options missed a valid WORLD value.

## Test plan
- [x] Comment includes waterworld
- [ ] shellcheck / existing shell-and-python-linting CI on PR

Aerial campaign micro-PR (docs hygiene). Spec: `specs/aerial-autonomy-stack/2026-07-14-1.md` (Team of Light dual-agent; Composer cloud not mid-wired — scoped + Bartok-reviewed one-line).