### PR TITLE
docs: honest gym --mode learn exit and PX4 params placeholder

### DIFF
--- a/tools_and_docs/docs/params/x650-px4-1.17.params
+++ b/tools_and_docs/docs/params/x650-px4-1.17.params
@@ -1,1 +1,10 @@
-TODO
+# Placeholder: Holybro X650 + PX4 1.17 parameters for aerial-autonomy-stack
+#
+# This file is intentionally not a loadable parameter dump.
+# Export a full set from PX4 / QGroundControl for your airframe after bench
+# calibration, then replace this placeholder when contributing a verified dump.
+#
+# For a complete ArduCopter example in the same kit family, see:
+#   x650-arducopter-4.6.params
+#
+# Related: tools_and_docs/docs/BOM.md (X650 kit) and SETUP_AVIONICS.md

--- a/tools_and_docs/gym_run.py
+++ b/tools_and_docs/gym_run.py
@@ -147,7 +147,12 @@ def main():
         envs.close()
 
     elif args.mode == "learn":
-        print("TODO")
+        print(
+            "Learning mode is not implemented yet (placeholder).\n"
+            "Use --mode step / speedup / vectorenv-speedup for sim benchmarks.\n"
+            "Gymnasium RL env work is tracked on the project roadmap (see open issues)."
+        )
+        raise SystemExit(2)
         # env = gym.make("AASEnv-v0")
         # try:
         #     # check_env(env) # Throws warning


### PR DESCRIPTION
## Summary
- `tools_and_docs/gym_run.py --mode learn`: replace bare `print(\"TODO\")` with a clear not-implemented message and **exit code 2** (keeps the commented prototype below for future RL work).
- `tools_and_docs/docs/params/x650-px4-1.17.params`: replace the solitary `TODO` token with a **comment-only** placeholder so the file cannot be mistaken for a loadable PX4 parameter named TODO; points to the full ArduCopter sibling dump and BOM/avionics docs.

## Why
Honest failure modes and safe param stubs reduce user confusion for roadmap surfaces (Gymnasium RL mode, X650 PX4 dump) without pretending incomplete paths work.

## Test plan
- [x] `ruff check --select E9,F,B tools_and_docs/gym_run.py` (pass)
- [x] params file is all `#` comment lines
- [ ] PR lint workflow

No flight/safety code paths changed.

Aerial campaign micro-PR. Spec: `specs/aerial-autonomy-stack/2026-07-14-2.md` (dual-agent; Composer cloud not mid-wired — Grok-spec + Bartok review micro-diff).