### PR TITLE
fix(gym): exit 2 when --mode learn is not implemented

### DIFF
--- a/tools_and_docs/gym_run.py
+++ b/tools_and_docs/gym_run.py
@@ -5,6 +5,7 @@ import time
 import itertools
 import subprocess
 import shutil
+import sys
 
 # from gymnasium.utils.env_checker import check_env
 # from stable_baselines3 import PPO
@@ -147,7 +148,12 @@ def main():
         envs.close()
 
     elif args.mode == "learn":
-        print("TODO")
+        print(
+            "Error: --mode learn is not implemented yet "
+            "(see commented stable-baselines3 PPO prototype below).",
+            file=sys.stderr,
+        )
+        sys.exit(2)
         # env = gym.make("AASEnv-v0")
         # try:
         #     # check_env(env) # Throws warning


### PR DESCRIPTION
## Summary
- `tools_and_docs/gym_run.py --mode learn`: replace bare `print("TODO")` with a clear not-implemented message on stderr and **exit code 2**.
- Keeps the commented stable-baselines3 PPO prototype for future work.

## Motivation
Empty success on an unimplemented learning path is easy to miss in scripts/automation.

## Test plan
- [x] `python3 -m py_compile tools_and_docs/gym_run.py`
- [x] `python3 tools_and_docs/gym_run.py --mode learn` → exit 2
- [ ] CI shell/python lint if applicable