### PR TITLE
docs(params): honest placeholder for PX4 1.17 X650 dump

### DIFF
--- a/tools_and_docs/docs/params/x650-px4-1.17.params
+++ b/tools_and_docs/docs/params/x650-px4-1.17.params
@@ -1,1 +1,6 @@
-TODO
+# Placeholder: onboard PX4 v1.17 parameter dump for X650 is not yet exported.
+# Use QGC or `param save` from SITL/HITL and replace this file with a real dump.
+# See x650-arducopter-4.6.params for the ArduPilot counterpart format.
+#
+# This file intentionally has no "Vehicle-Id Component-Id Name Value Type" rows
+# so it must not be treated as a loadable param set until a real export lands.


### PR DESCRIPTION
## Summary
- Replace bare `TODO` in `tools_and_docs/docs/params/x650-px4-1.17.params` with an honest comment placeholder.
- Point maintainers/users at QGC/`param save` and the ArduCopter counterpart file.
- No invented parameter values (was rejected earlier as empty TODO file).

## Test plan
- [x] File is comment-only (not loadable rows)
- [ ] Docs-only review