### PR TITLE
docs(run): fix GROUND_ID comment to say ground container

### DIFF
--- a/tools_and_docs/deploy_run.sh
+++ b/tools_and_docs/deploy_run.sh
@@ -21,7 +21,7 @@ ODOM="${ODOM:-none}" # Options: none (default), openvins, fastlio, superodom, mi
 SIM_SUBNET="${SIM_SUBNET:-10.42}" # Simulation subnet (default = 10.42)
 AIR_SUBNET="${AIR_SUBNET:-10.22}" # Inter-vehicle subnet (default = 10.22)
 SIM_ID="${SIM_ID:-100}" # Last byte of the simulation container IP (default = 100)
-GROUND_ID="${GROUND_ID:-101}" # Last byte of the simulation container IP (default = 101)
+GROUND_ID="${GROUND_ID:-101}" # Last byte of the ground container IP (default = 101)
 #
 DRONE_TYPE="${DRONE_TYPE:-quad}" # Options: quad (default), vtol, tail
 DRONE_ID="${DRONE_ID:-1}" # Id of aircraft (default = 1)

--- a/tools_and_docs/sim_run.sh
+++ b/tools_and_docs/sim_run.sh
@@ -13,7 +13,7 @@ ODOM="${ODOM:-none}" # Options: none (default), openvins, fastlio, superodom, mi
 SIM_SUBNET="${SIM_SUBNET:-10.42}" # Simulation subnet (default = 10.42) Note: this is overridden if INSTANCE != 0
 AIR_SUBNET="${AIR_SUBNET:-10.22}" # Inter-vehicle subnet (default = 10.22) Note: this is overridden if INSTANCE != 0
 SIM_ID="${SIM_ID:-100}" # Last byte of the simulation container IP (default = 100)
-GROUND_ID="${GROUND_ID:-101}" # Last byte of the simulation container IP (default = 101)
+GROUND_ID="${GROUND_ID:-101}" # Last byte of the ground container IP (default = 101)
 #
 NUM_QUADS="${NUM_QUADS:-1}" # Number of quadcopters (default = 1)
 NUM_VTOLS="${NUM_VTOLS:-0}" # Number of VTOLs (default = 0)


### PR DESCRIPTION
## Summary
One-line comment fix in `sim_run.sh` and `deploy_run.sh`: `GROUND_ID` is the **ground** container last IP byte (and ROS domain for ground), not the simulation container (`SIM_ID`).

## Motivation
The twin defaults were copy-pasted; only SIM_ID is the sim container. Avoids confusion when reading env-var headers before wiring multi-instance networks.

## Verification
- Diff is comment-only
- `bash -n tools_and_docs/sim_run.sh tools_and_docs/deploy_run.sh`

No behavior change.