### PR TITLE
docs(params): clarify empty PX4 1.17 X650 dump placeholder

### DIFF
--- a/tools_and_docs/docs/params/x650-px4-1.17.params
+++ b/tools_and_docs/docs/params/x650-px4-1.17.params
@@ -1,1 +1,3 @@
-TODO
+# Placeholder: PX4 1.17 Holybro X650 parameter dump not checked in yet.
+# Export onboard params (QGC/MAVLink) and replace this file when available.
+# See sister file x650-arducopter-4.6.params for the ArduPilot dump format.


### PR DESCRIPTION
## Summary
`tools_and_docs/docs/params/x650-px4-1.17.params` currently contains only the word `TODO`. Turn it into `#` comment lines explaining the dump is pending, matching honesty of the ArduPilot sister file without inventing param values.

## Verification
- Comment-only; no fake vehicle parameters