### PR TITLE
docs(aircraft): fix scrip→script typo in analyze_bag.sh

### DIFF
--- a/aircraft/aircraft_resources/scripts/analyze_bag.sh
+++ b/aircraft/aircraft_resources/scripts/analyze_bag.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Analyze an aircraft's rosbag using PlotJuggler
-# To use this scrip, enable RECORD_ROSBAG in 'aircraft.yml.erb'
+# To use this script, enable RECORD_ROSBAG in 'aircraft.yml.erb'
 
 TMUX_PANE="logging.0" # The tmux <window_name>.<pane_index> where the recording is happening
 BAG_PARENT_DIR="/aas/rosbags" # The directory where bags are saved


### PR DESCRIPTION
## Summary
One-character typo in a comment: \"this scrip\" → \"this script\".

## Verification
Comment-only; `bash -n aircraft/aircraft_resources/scripts/analyze_bag.sh`