### PR TITLE
docs(gym): clarify learn mode is not implemented yet

### DIFF
--- a/tools_and_docs/gym_run.py
+++ b/tools_and_docs/gym_run.py
@@ -147,7 +147,7 @@ def main():
         envs.close()
 
     elif args.mode == "learn":
-        print("TODO")
+        print("learn mode is not implemented yet (PPO training remains commented out below).")
         # env = gym.make("AASEnv-v0")
         # try:
         #     # check_env(env) # Throws warning


### PR DESCRIPTION
## Summary
\`--mode learn\` still only prints a stub; change \`print(\"TODO\")\` to a clear one-line message so operators know training is not wired.

## Motivation
Bare \`TODO\` is ambiguous. Prior PRs that added exit codes / help churn were rightly closed as over-scoped (#104/#108); this is intentionally a **single string** change only.

## Verification
- One \`print\` line changed under \`learn\`
- \`python3 -m py_compile tools_and_docs/gym_run.py\`