### PR TITLE
docs(sim): fix analyze_logs.sh header (scrip → script)

### DIFF
--- a/simulation/simulation_resources/scripts/analyze_logs.sh
+++ b/simulation/simulation_resources/scripts/analyze_logs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# This scrip allows to analyze ArduPilot logs using MAVExplorer and PX4 logs with flight_review
+# This script analyzes ArduPilot logs using MAVExplorer and PX4 logs with flight_review
 # Note that the 3D and map features of flight_review require to add API keys to _github_clones/flight_review/app/config_default.ini
 
 NUM_DRONES=$((NUM_QUADS + NUM_VTOLS + NUM_TAILS))


### PR DESCRIPTION
## Summary
Header comment in `simulation/.../analyze_logs.sh`: typo `scrip` and awkward "allows to" → clear "This script analyzes…".

## Notes
- Comment-only (analyze_bag.sh typo remains on open PR #112)
- AI-assisted; human-reviewed

## Verification
- `bash -n` on the script