### PR TITLE
docs(gym): document --mode choices and learn status in --help

### DIFF
--- a/tools_and_docs/gym_run.py
+++ b/tools_and_docs/gym_run.py
@@ -21,7 +21,7 @@ gym.register(
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--mode", type=str, default="step", choices=["step", "speedup", "vectorenv-speedup", "learn"])
+    parser.add_argument("--mode", type=str, default="step", choices=["step", "speedup", "vectorenv-speedup", "learn"], help="Run mode: step, speedup, vectorenv-speedup, or learn (learn not implemented yet)")
     parser.add_argument("--repetitions", type=int, default=1),
     parser.add_argument("--autopilot", type=str, default="px4", choices=["px4", "ardupilot"])
     parser.add_argument("--camera", action=argparse.BooleanOptionalAction, default=True, help="Enable/Disable Camera")


### PR DESCRIPTION
## Summary
Adds argparse `help=` for `--mode` so `gym_run.py --help` lists choices and notes that `learn` is not implemented yet.

## Why help-only
Prior behavioral learn-mode exits were closed as over-scope for this repo; this PR is strictly UX documentation.

## Verification
- One-line argparse metadata change  ·  no dispatch changes
- AI-assisted; human-reviewed