### PR TITLE
docs(gym): add --repetitions help string

### DIFF
--- a/tools_and_docs/gym_run.py
+++ b/tools_and_docs/gym_run.py
@@ -22,7 +22,7 @@ gym.register(
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--mode", type=str, default="step", choices=["step", "speedup", "vectorenv-speedup", "learn"])
-    parser.add_argument("--repetitions", type=int, default=1),
+    parser.add_argument("--repetitions", type=int, default=1, help="Repetitions for speedup modes (default: 1)")
     parser.add_argument("--autopilot", type=str, default="px4", choices=["px4", "ardupilot"])
     parser.add_argument("--camera", action=argparse.BooleanOptionalAction, default=True, help="Enable/Disable Camera")
     parser.add_argument("--lidar", action=argparse.BooleanOptionalAction, default=True, help="Enable/Disable Lidar")


### PR DESCRIPTION
## Summary
Documents `--repetitions` for speedup suite runs and drops a no-op trailing comma after `add_argument`.

## Verification
- Pure argparse metadata
- AI-assisted; human-reviewed