### PR TITLE
docs(bom): fix "allows triggering" grammar in RTL safety note

### DIFF
--- a/tools_and_docs/docs/BOM.md
+++ b/tools_and_docs/docs/BOM.md
@@ -207,7 +207,7 @@ RSSI_CHANNEL        16              # Tells the flight controller to read Channe
 
 ## Triple Redundancy for RTL
 
-For safety, the proposed configuration allows to trigger an emergency RTL through 3 **independent** channels:
+For safety, the proposed configuration allows triggering an emergency RTL through 3 **independent** channels:
 
 1. Flight mode change using a switch on the RC (Boxer-R86C link)
 2. Flight mode change from QGC user interface (telemetry radio link)


### PR DESCRIPTION
### Summary
Polishes one safety sentence in `BOM.md`: **allows to trigger** → **allows triggering**.

### Why
Same grammar cleanup as the merged deploy_run comment polish (`allows using`). Clearer operator-facing docs; no hardware or procedure changes.

### Verification
- Diff is a single phrase in the Triple Redundancy for RTL section
- No table, cost, or link edits

AI-assisted; human-reviewed.