### PR TITLE
docs(sim): require adding API keys wording in analyze_logs.sh

### DIFF
--- a/simulation/simulation_resources/scripts/analyze_logs.sh
+++ b/simulation/simulation_resources/scripts/analyze_logs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script analyzes ArduPilot logs using MAVExplorer and PX4 logs with flight_review
-# Note that the 3D and map features of flight_review require to add API keys to _github_clones/flight_review/app/config_default.ini
+# Note that the 3D and map features of flight_review require adding API keys to _github_clones/flight_review/app/config_default.ini
 
 NUM_DRONES=$((NUM_QUADS + NUM_VTOLS + NUM_TAILS))
 if [[ -n "$NUM_DRONES" && "$NUM_DRONES" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
### Summary
Header comment in `analyze_logs.sh`: **require to add** → **require adding** API keys for flight_review 3D/map features.

### Motivation
Small readability fix next to the already-merged `scrip`→`script` header cleanups. No behavior change.

### Verification
- `bash -n` on the script
- Comment-only diff

Human-reviewed micro-docs.