### PR TITLE
docs(yolo): clarify disabled GPU pipeline TODO comment

### DIFF
--- a/aircraft/aircraft_ws/src/yolo_py/yolo_py/yolo_node.py
+++ b/aircraft/aircraft_ws/src/yolo_py/yolo_py/yolo_node.py
@@ -68,7 +68,7 @@ class YoloInferenceNode(Node):
     def run_inference_loop(self):
         # Acquire video stream
         if self.architecture == 'x86_64':
-            # # GPU pipeline: TODO NOT WORKING
+            # # GPU pipeline: TODO — not working (disabled)
             # gst_pipeline_string = (
             #     f"udpsrc port={self.udp_port} ! "
             #     "application/x-rtp, media=(string)video, encoding-name=(string)H264 ! "


### PR DESCRIPTION
### Summary
Clarify the intentionally disabled x86 GPU GStreamer path marker in `yolo_node.py`:
`TODO NOT WORKING` → `TODO — not working (disabled)`.

### Why
Makes the comment scannable without implying a live broken path. No pipeline code enabled.

### Verification
- Comment-only one line
- Inference / HITL / arming untouched

AI-assisted; human-reviewed.