### PR TITLE
docs(ubuntu): drop double space in Power Mode step

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ NUM_QUADS=1 NUM_VTOLS=1 WORLD=swiss_town RTF=3 PLOT=true ./sim_run.sh    # Start
 #  HEADLESS/CAMERA/LIDAR=true, false
 #  NUM_QUADS/NUM_VTOLS/NUM_TAILS=0, 1, ...
 #  WORLD=impalpable_greyness, apple_orchard, shibuya_crossing, swiss_town, waterworld
-#  RTF=1, 2, ... (real-time-factor, use 0 for "as fast as possible)
+#  RTF=1, 2, ... (real-time-factor, use 0 for "as fast as possible")
 #  INSTANCE=0, 1, ... (integer ID to run multiple parallel simulations)
 #  PLOT=true, false (requires pymavlink, pyulog, pymap3d)
 ```

--- a/tools_and_docs/docs/RATIONALE.md
+++ b/tools_and_docs/docs/RATIONALE.md
@@ -4,7 +4,7 @@ This project aims to speed up the ideation-development-simulation-deployment cyc
 
 ## The Many Facets of the Sim2real Gap
 
-The *sim2real gap* is an euphemism for robotic projects that work well on a developer's laptop but not so much in the field.
+The *sim2real gap* is a euphemism for robotic projects that work well on a developer's laptop but not so much in the field.
 Aerial sim2real research often focuses on modeling and simulation of complex aerodynamics effects.
 
 Nonetheless, at deployment time, an equally important component of *sim2real gap* arises from [system design](https://arxiv.org/abs/2510.20808)—in particular, software tooling and engineering, where the dynamic range between ["average and the best is 50-to-1, maybe 100-to-1"](https://www.youtube.com/watch?v=wTgQ2PBiz-g&t=35s).

--- a/tools_and_docs/docs/REQUIREMENTS_UBUNTU.md
+++ b/tools_and_docs/docs/REQUIREMENTS_UBUNTU.md
@@ -15,7 +15,7 @@
   - Update and restart for "Device Firmware", if necessary
 - On Ubuntu 22/24, in "Software & Updates", select "Using NVIDIA driver metapackage from `nvidia-driver-580` (proprietary)"
 - On Ubuntu 26, use `sudo ubuntu-drivers install nvidia-driver-580`
-- (optional) Go to "Settings" -> "Power", select  the "Performance" "Power Mode" and disable all "Power Saving Options"
+- (optional) Go to "Settings" -> "Power", select the "Performance" "Power Mode" and disable all "Power Saving Options"
 
 ```sh
 sudo apt update && sudo apt upgrade

--- a/tools_and_docs/docs/SETUP_CHRONY.md
+++ b/tools_and_docs/docs/SETUP_CHRONY.md
@@ -1,6 +1,6 @@
 # Setup Chrony
 
-> Follow these steps to let the Jetson synchronize their time to the `ground-image` computer over `AIR_SUBNET` when without internet connectivity (for Zenoh, etc.)
+> Follow these steps to let the Jetson synchronize its time to the `ground-image` computer over `AIR_SUBNET` when without internet connectivity (for Zenoh, etc.)
 
 ## On the Ground Station Computer
 
@@ -52,7 +52,7 @@ sudo chronyc makestep
 
 On Jetson, check with:
 ```sh
-chronyc -n sources # NOte it might take some time for the Jetson to switch source
+chronyc -n sources # Note it might take some time for the Jetson to switch source
 ```
 
 If `[AIR_SUBNET].90.101` has a `^*` next to it, the Jetson is syncing to the ground computer


### PR DESCRIPTION
## Summary
`select  the "Performance"` → `select the "Performance"` in REQUIREMENTS_UBUNTU.md.

## Verification
Whitespace-only docs fix.
