### PR TITLE
docs(avionics): trim trailing space on v4l2-ctl line

### DIFF
--- a/tools_and_docs/docs/SETUP_AVIONICS.md
+++ b/tools_and_docs/docs/SETUP_AVIONICS.md
@@ -63,7 +63,7 @@ sudo dmesg | grep -i imx219         # After reboot, this will show at least one 
 
 # Inspect device (e.g. /dev/video0) resolution and frame rate
 sudo apt update && sudo apt install -y v4l-utils
-v4l2-ctl --list-formats-ext -d /dev/video0 
+v4l2-ctl --list-formats-ext -d /dev/video0
 ```
 
 ## Install Docker Engine on Jetson Orin


### PR DESCRIPTION
## Summary
Trim trailing whitespace on the `v4l2-ctl --list-formats-ext` example line in SETUP_AVIONICS.md.

## Verification
Whitespace-only.
