### PR TITLE
docs(chrony): Jetson agrees in number (its time)

### DIFF
--- a/tools_and_docs/docs/SETUP_CHRONY.md
+++ b/tools_and_docs/docs/SETUP_CHRONY.md
@@ -1,6 +1,6 @@
 # Setup Chrony
 
-> Follow these steps to let the Jetson synchronize their time to the `ground-image` computer over `AIR_SUBNET` when without internet connectivity (for Zenoh, etc.)
+> Follow these steps to let the Jetson synchronize its time to the `ground-image` computer over `AIR_SUBNET` when without internet connectivity (for Zenoh, etc.)
 
 ## On the Ground Station Computer
 


### PR DESCRIPTION
## Summary
SETUP_CHRONY intro: "the Jetson synchronize their time" → "its time".

## Motivation
Singular subject ("the Jetson") should take singular possessive.

## Verification
One-line docs edit in `tools_and_docs/docs/SETUP_CHRONY.md`.

Human-reviewed micro copy fix.
