### PR TITLE
docs(avionics): trim trailing space on Follow these steps

### DIFF
--- a/tools_and_docs/docs/SETUP_AVIONICS.md
+++ b/tools_and_docs/docs/SETUP_AVIONICS.md
@@ -51,7 +51,7 @@ sdkmanager                          # Log in with your https://developer.nvidia.
 ```sh
 sudo /opt/nvidia/jetson-io/jetson-io.py
 
-# Follow these steps: 
+# Follow these steps:
 #   "Configure Jetson 24pin CSI Connector"
 #   -> "Configure for compatible hardware"
 #   -> "Camera IMX219 Dual" (even if only using one)


### PR DESCRIPTION
## Summary
Trim trailing whitespace on the `# Follow these steps:` comment in SETUP_AVIONICS.md.

## Verification
Whitespace-only.
