### PR TITLE
docs(avionics): trim trailing space after firmware.html link

### DIFF
--- a/tools_and_docs/docs/SETUP_AVIONICS.md
+++ b/tools_and_docs/docs/SETUP_AVIONICS.md
@@ -162,7 +162,7 @@ docker run -it --rm --entrypoint bash -v ~/Downloads:/temp simulation-image -c \
   "cd /aas/github_apps/ardupilot && ./waf configure --board Pixhawk6X && ./waf plane && cp build/Pixhawk6X/bin/*.apj /temp/"
 ```
 
-To flash the newly created `.px4` or `.apj` file to your autopilot board, follow [QGC's User Guide](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/setup_view/firmware.html) 
+To flash the newly created `.px4` or `.apj` file to your autopilot board, follow [QGC's User Guide](https://docs.qgroundcontrol.com/Stable_V5.0/en/qgc-user-guide/setup_view/firmware.html)
 
 ## PX4: Configure 6X's Network and DDS Client
 


### PR DESCRIPTION
## Summary
Trim trailing whitespace after the PX4 firmware.html documentation link in SETUP_AVIONICS.md.

## Verification
Whitespace-only.
