### PR TITLE
docs(autopilot): fix MAV_STATE comment spelling (unknown)

### DIFF
--- a/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
@@ -214,7 +214,7 @@ void ArdupilotInterface::state_callback(const State::SharedPtr msg)
     std::unique_lock<std::shared_mutex> lock(node_data_mutex_); // Use unique_lock for data writes
     //add string for msg->mode, remove in_transition_mode_; in_transition_to_fw_
     armed_flag_ = msg->armed;
-    mav_state_ = msg->system_status; // MAV_STATE: MAV_STATE_CALIBRATING = 2, MAV_STATE_STANDBY = 3, MAV_STATE_ACTIVE = 4 (0: unkown, 5,6: failsafe, 8: flight termination, 1,7: boot)
+    mav_state_ = msg->system_status; // MAV_STATE: MAV_STATE_CALIBRATING = 2, MAV_STATE_STANDBY = 3, MAV_STATE_ACTIVE = 4 (0: unknown, 5,6: failsafe, 8: flight termination, 1,7: boot)
     ardupilot_mode_ = msg->mode; // See https://github.com/mavlink/mavros/blob/ros2/mavros_msgs/msg/State.msg
     if ((aircraft_fsm_state_ == ArdupilotInterfaceState::LANDED) && (mav_state_ == 3)) {
         aircraft_fsm_state_ = ArdupilotInterfaceState::STARTED; // Reset ArduPilot interface state when in standby after landing


### PR DESCRIPTION
## Summary
Correct \`unkown\` → \`unknown\` in the MAV_STATE comment on the ArduPilot interface state callback.

## Motivation
Comment only; keeps status enum notes accurate for readers skimming system_status mapping.

## Verification
- Reviewed the single-line comment change; no runtime behavior change.
- AI-assisted; human-reviewed. Human author only.