### PR TITLE
docs(autopilot): fix erroneously spelling in VTOL MC_HOVER TODO

### DIFF
--- a/aircraft/aircraft_ws/src/autopilot_interface/src/px4_interface.cpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/px4_interface.cpp
@@ -1009,7 +1009,7 @@ void PX4Interface::abort_action()
             std::unique_lock<std::shared_mutex> lock(node_data_mutex_);
             aircraft_fsm_state_ = PX4InterfaceState::FW_CRUISE;
         }
-    } // TODO: if a VTOL errenously ended in the MC_HOVER state, it would not be recoverable by PX4Interface as an explicit transition is not exposed (land via QGC)
+    } // TODO: if a VTOL erroneously ended in the MC_HOVER state, it would not be recoverable by PX4Interface as an explicit transition is not exposed (land via QGC)
     active_srv_or_act_flag_.store(false);
 }
 


### PR DESCRIPTION
## Summary
Correct \`errenously\` → \`erroneously\` in the PX4Interface VTOL MC_HOVER recovery TODO comment.

## Motivation
Spelling fix in operator-facing engineering note; no behavior change.

## Verification
- Single comment token fix in \`px4_interface.cpp\`.
- AI-assisted; human-reviewed.