### PR TITLE
docs(autopilot): hyphenate double-check in angular velocity comment

### DIFF
--- a/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
@@ -170,7 +170,7 @@ void ArdupilotInterface::local_position_odom_callback(const Odometry::SharedPtr 
     velocity_[0] = msg->twist.twist.linear.x; // Body frame
     velocity_[1] = msg->twist.twist.linear.y;
     velocity_[2] = msg->twist.twist.linear.z;
-    angular_velocity_[0] = msg->twist.twist.angular.x; // TODO: double check
+    angular_velocity_[0] = msg->twist.twist.angular.x; // TODO: double-check
     angular_velocity_[1] = msg->twist.twist.angular.y;
     angular_velocity_[2] = msg->twist.twist.angular.z;
     // See also topics /mavros/local_position/velocity_body, /mavros/local_position/velocity_local


### PR DESCRIPTION
## Summary
Normalize \`double check\` → \`double-check\` on the ArduPilot angular velocity assignment comment (matches existing \`double-check\` wording elsewhere).

## Motivation
Consistency of engineering TODOs across autopilot interfaces.

## Verification
- Comment-only. AI-assisted; human-reviewed.