### PR TITLE
docs(offboard): hyphenate double-check in ArduPilot guided comment

### DIFF
--- a/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp
+++ b/aircraft/aircraft_ws/src/offboard_control/src/ardupilot_guided.cpp
@@ -132,7 +132,7 @@ void ArdupilotGuided::local_position_odom_callback(const Odometry::SharedPtr msg
     velocity_[0] = msg->twist.twist.linear.x; // Body frame
     velocity_[1] = msg->twist.twist.linear.y;
     velocity_[2] = msg->twist.twist.linear.z;
-    angular_velocity_[0] = msg->twist.twist.angular.x; // TODO: double check
+    angular_velocity_[0] = msg->twist.twist.angular.x; // TODO: double-check
     angular_velocity_[1] = msg->twist.twist.angular.y;
     angular_velocity_[2] = msg->twist.twist.angular.z;
     // See also topics /mavros/local_position/velocity_body, /mavros/local_position/velocity_local


### PR DESCRIPTION
## Summary
Normalize \`double check\` → \`double-check\` in \`ardupilot_guided.cpp\` angular velocity TODO.

## Motivation
Match sibling interface comments for skim-ability.

## Verification
- Comment-only. AI-assisted; human-reviewed.