### PR TITLE
docs(chrony): Jetson agrees in number (its time)

### DIFF
--- a/tools_and_docs/docs/SETUP_CHRONY.md
+++ b/tools_and_docs/docs/SETUP_CHRONY.md
@@ -1,6 +1,6 @@
 # Setup Chrony
 
-> Follow these steps to let the Jetson synchronize their time to the `ground-image` computer over `AIR_SUBNET` when without internet connectivity (for Zenoh, etc.)
+> Follow these steps to let the Jetson synchronize its time to the `ground-image` computer over `AIR_SUBNET` when without internet connectivity (for Zenoh, etc.)
 
 ## On the Ground Station Computer
 


### PR DESCRIPTION
## Summary
Fix subject-verb/number agreement in chrony setup blurb: Jetson … \`their time\` → \`its time\`.

## Motivation
Each Jetson is singular in the instruction flow.

## Verification
- Docs only SETUP_CHRONY.md. AI-assisted; human-reviewed.