### PR TITLE
docs(autopilot): space after // in state_callback TODO

### DIFF
--- a/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
+++ b/aircraft/aircraft_ws/src/autopilot_interface/src/ardupilot_interface.cpp
@@ -212,7 +212,7 @@ void ArdupilotInterface::home_position_home_callback(const HomePosition::SharedP
 void ArdupilotInterface::state_callback(const State::SharedPtr msg)
 {
     std::unique_lock<std::shared_mutex> lock(node_data_mutex_); // Use unique_lock for data writes
-    //add string for msg->mode, remove in_transition_mode_; in_transition_to_fw_
+    // add string for msg->mode, remove in_transition_mode_; in_transition_to_fw_
     armed_flag_ = msg->armed;
     mav_state_ = msg->system_status; // MAV_STATE: MAV_STATE_CALIBRATING = 2, MAV_STATE_STANDBY = 3, MAV_STATE_ACTIVE = 4 (0: unkown, 5,6: failsafe, 8: flight termination, 1,7: boot)
     ardupilot_mode_ = msg->mode; // See https://github.com/mavlink/mavros/blob/ros2/mavros_msgs/msg/State.msg


### PR DESCRIPTION
## Summary
Format the inline maintainer TODO so it reads as a normal open remnant: \`//add string...\` → \`// add string...\`.

## Motivation
Consistent comment style next to surrounding autopilot interface notes.

## Verification
- Comment whitespace only in \`ardupilot_interface.cpp\`. AI-assisted; human-reviewed.