### PR TITLE
Tune `WindEffects` for Multicopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ cancellable_action "ros2 action send_goal /Drone${DRONE_ID}/offboard_action \
 > ```sh
 > python3 /aas/simulation_resources/scripts/gz_wind.py --from_west 0.0 --from_south 3.0
 > python3 /aas/simulation_resources/scripts/gz_wind.py --stop_wind
+> # Note: only use with the quadrotor models as the simulated airspeed sensors on VTOLs/tailsitters are not Gazebo wind-aware
 > ```
 > </details>
 > <details>
@@ -554,9 +555,9 @@ docker exec -it aircraft-container-inst0_1 tmux attach
 ## Known Issues
 
 - ArduPilot SITL for Iris uses option -f that also sets "external": True, this is not the case for the Alti Transition from ArduPilot/SITL_Models
-- ArduPilot SITL crashes when the swan_k1_hwing tailsitter model lands
+- ArduPilot SITL throws a floating point exception when the swan_k1_hwing tailsitter model lands (ignored with SIM_FLOAT_EXCEPT 0)
+- Gazebo WindEffects reach all vehicles aerodynamically, but no airspeed sensor (PX4 SENS_EN_ARSPDSIM, ArduPlane SIM_ARSPD_*, gz AirSpeed)
 - QGC will only connect to the first 10 ArduPilot vehicles when GND_CONTAINER=false because of settings in QGroundControl.ini
-- Gazebo WindEffects plugin affects cruise speeds and it is disabled for the standard_vtol's model.sdf.erb
 - Command 178 MAV_CMD_DO_CHANGE_SPEED is accepted but not effective in changing speed for ArduPilot VTOL
 - QGC does not save roll and pitch in the telemetry bar for PX4 VTOLs (MAV_TYPE 22)
 - PX4 quad max tilt is limited by the anti-windup gain (zero it to deactivate it): const float arw_gain = 2.f / _gain_vel_p(0);

--- a/simulation/simulation_resources/aircraft_models/alti_transition_quad/model.sdf.erb
+++ b/simulation/simulation_resources/aircraft_models/alti_transition_quad/model.sdf.erb
@@ -4,7 +4,6 @@
     <pose>0 0 0 0 0 0</pose>
 
     <link name="base_link">
-      <enable_wind>true</enable_wind>
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>-0.1 0 0 0 0 0</pose>

--- a/simulation/simulation_resources/aircraft_models/iris_with_ardupilot/model.sdf.erb
+++ b/simulation/simulation_resources/aircraft_models/iris_with_ardupilot/model.sdf.erb
@@ -5,6 +5,7 @@
     <model name='iris'>
       <pose>0 0 0 0 0 0</pose>
       <link name='base_link'>
+        <!-- Allow the WindEffects plugin to push the quad frame -->
         <enable_wind>true</enable_wind>
         <velocity_decay>
           <linear>0.0</linear>

--- a/simulation/simulation_resources/aircraft_models/standard_vtol/model.sdf.erb
+++ b/simulation/simulation_resources/aircraft_models/standard_vtol/model.sdf.erb
@@ -4,7 +4,6 @@
   <model name='standard_vtol'>
     <pose>0 0 0.246 0 0 0</pose>
     <link name='base_link'>
-      <!-- <enable_wind>true</enable_wind> --> <!-- Gazebo WindEffects are disabled for PX4 fixed-wing SITL -->
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>

--- a/simulation/simulation_resources/aircraft_models/x500/model.sdf.erb
+++ b/simulation/simulation_resources/aircraft_models/x500/model.sdf.erb
@@ -6,6 +6,7 @@
     <self_collide>false</self_collide>
     <static>false</static>
     <link name="base_link">
+      <!-- Allow the WindEffects plugin to push the quad frame -->
       <enable_wind>true</enable_wind>
       <inertial>
         <mass>2.0</mass>

--- a/simulation/simulation_resources/scripts/gz_wind.py
+++ b/simulation/simulation_resources/scripts/gz_wind.py
@@ -1,4 +1,10 @@
 """
+This scripts allows to set wind velocity of plugin gz::sim::systems::WindEffects
+- Wind reaches each LiftDrag/AdvancedLiftDrag/MulticopterMotorModel plugin, on every vehicle
+- On the X500 and Iris, wind also applies a force on the base_link through tag <enable_wind>
+- However, PX4's SENS_EN_ARSPDSIM, ArduPlane (SIM_)ARSPD_*, and gz::sim::systems::AirSpeed on VTOLs/tailsitters are blind to it
+- Thus, this script is only recommended for use with QUADS
+
 Use as:
     python3 gz_wind.py --from_west 0.0 --from_south 3.0
     python3 gz_wind.py --stop_wind

--- a/simulation/simulation_resources/simulation_worlds/apple_orchard.sdf
+++ b/simulation/simulation_resources/simulation_worlds/apple_orchard.sdf
@@ -28,7 +28,7 @@
       <render_engine>ogre2</render_engine>
     </plugin>
     <plugin filename="gz-sim-wind-effects-system" name="gz::sim::systems::WindEffects">
-      <force_approximation_scaling_factor>1</force_approximation_scaling_factor>
+      <force_approximation_scaling_factor>0.15</force_approximation_scaling_factor> <!-- Tuned: hovering x500 leans ~4 deg in 5 m/s wind -->
       <horizontal>
         <magnitude> <!-- Randomized strength -->
           <time_for_rise>5</time_for_rise> <!-- 5s to reach full strength -->

--- a/simulation/simulation_resources/simulation_worlds/impalpable_greyness.sdf
+++ b/simulation/simulation_resources/simulation_worlds/impalpable_greyness.sdf
@@ -28,7 +28,7 @@
       <render_engine>ogre2</render_engine>
     </plugin>
     <plugin filename="gz-sim-wind-effects-system" name="gz::sim::systems::WindEffects">
-      <force_approximation_scaling_factor>1</force_approximation_scaling_factor>
+      <force_approximation_scaling_factor>0.15</force_approximation_scaling_factor> <!-- Tuned: hovering x500 leans ~4 deg in 5 m/s wind -->
       <horizontal>
         <magnitude> <!-- Randomized strength -->
           <time_for_rise>5</time_for_rise> <!-- 5s to reach full strength -->

--- a/simulation/simulation_resources/simulation_worlds/shibuya_crossing.sdf
+++ b/simulation/simulation_resources/simulation_worlds/shibuya_crossing.sdf
@@ -28,7 +28,7 @@
       <render_engine>ogre2</render_engine>
     </plugin>
     <plugin filename="gz-sim-wind-effects-system" name="gz::sim::systems::WindEffects">
-      <force_approximation_scaling_factor>1</force_approximation_scaling_factor>
+      <force_approximation_scaling_factor>0.15</force_approximation_scaling_factor> <!-- Tuned: hovering x500 leans ~4 deg in 5 m/s wind -->
       <horizontal>
         <magnitude> <!-- Randomized strength -->
           <time_for_rise>5</time_for_rise> <!-- 5s to reach full strength -->

--- a/simulation/simulation_resources/simulation_worlds/swiss_town.sdf
+++ b/simulation/simulation_resources/simulation_worlds/swiss_town.sdf
@@ -28,7 +28,7 @@
       <render_engine>ogre2</render_engine>
     </plugin>
     <plugin filename="gz-sim-wind-effects-system" name="gz::sim::systems::WindEffects">
-      <force_approximation_scaling_factor>1</force_approximation_scaling_factor>
+      <force_approximation_scaling_factor>0.15</force_approximation_scaling_factor> <!-- Tuned: hovering x500 leans ~4 deg in 5 m/s wind -->
       <horizontal>
         <magnitude> <!-- Randomized strength -->
           <time_for_rise>5</time_for_rise> <!-- 5s to reach full strength -->

--- a/simulation/simulation_resources/simulation_worlds/waterworld.sdf
+++ b/simulation/simulation_resources/simulation_worlds/waterworld.sdf
@@ -28,7 +28,7 @@
       <render_engine>ogre2</render_engine>
     </plugin>
     <plugin filename="gz-sim-wind-effects-system" name="gz::sim::systems::WindEffects">
-      <force_approximation_scaling_factor>1</force_approximation_scaling_factor>
+      <force_approximation_scaling_factor>0.15</force_approximation_scaling_factor> <!-- Tuned: hovering x500 leans ~4 deg in 5 m/s wind -->
       <horizontal>
         <magnitude> <!-- Randomized strength -->
           <time_for_rise>5</time_for_rise> <!-- 5s to reach full strength -->


### PR DESCRIPTION
Summary of vehicle components/sensors/plugins that are affected by Gazebo's `WindEffects` plugin

| Vehicle | `<enable_wind>` tag, i.e., WindEffects also applies a force on the base_link | `Lift` `Drag` | `Advanced` `LiftDrag` | `Multicopter` `MotorModel` | Airspeed | `Apply` `JointForce` | 
|---|---|---|---|---|---|---|
| x500 | ✅ yes | 1 ✅ (fuselage drag) | n/a | 4 ✅ | n/a | n/a |
| standard_vtol | n/a | 3 ✅ (wings) | n/a | 5 ✅ | PX4's `SENS_EN_ARSPDSIM` ❌ | n/a |
| quadtailsitter | n/a | n/a | 1 ✅ (airframe) | 4 ✅ | gz sensor `air_speed` and plugin `gz::sim::` `systems::AirSpeed` ❌ | n/a |
| iris | ✅ yes | 8 ✅ (rotor blades) | n/a | n/a | n/a | 4 ❌ (rotor revolute joints) |
| alti | n/a | 19 ✅ (9 airframe + 10 blades) | n/a | n/a | ArduPlane's `ARSPD_TYPE 2` ❌ (`SIM_ARSPD_*` / `SIM_WIND_*`) | n/a |
| swan | n/a | 8 ✅ (rotor blades) | 1 ✅ (airframe) | n/a | ArduPlane's `ARSPD_TYPE 2` ❌ (`SIM_ARSPD_*` / `SIM_WIND_*`) | 4 ❌ (rotor revolute joints) |

✅/❌ is whether a plugin/sensor uses the wind velocity from the `WindEffects` plugin

`ArduPilotPlugin`, `JointStatePublisher`, `JointPositionController` are also not `WindEffects`-aware