### PR TITLE
MCAP rosbags with allow list

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ NUM_QUADS=1 NUM_VTOLS=1 WORLD=swiss_town RTF=3 PLOT=true ./sim_run.sh    # Start
 #  WORLD=impalpable_greyness, apple_orchard, crematoria, shibuya_crossing, swiss_town, waterworld
 #  RTF=1, 2, ... (real-time-factor, use 0 for "as fast as possible")
 #  INSTANCE=0, 1, ... (integer ID to run multiple parallel simulations)
-#  PLOT=true, false (requires pymavlink, pyulog, pymap3d)
+#  PLOT/RECORD_ROSBAG=true, false (plotting requires pymavlink, pyulog, pymap3d)
 ```
 
 There are **3 different ways** to autonomously fly the drones (plus QGroundControl for operator supervision)
@@ -231,7 +231,7 @@ DRONE_ID=1 CAMERA=true LIDAR=false AIR_SUBNET=10.223 HEADLESS=true ./deploy_run.
 #  DRONE_TYPE=quad, vtol, tail
 #  AUTOPILOT=px4, ardupilot
 #  DRONE_ID=1, 2, ... (ROS_DOMAIN_ID of the drone, matching the MAV_SYS_ID/SYSID_THISMAV of the autpilot)
-#  HEADLESS/CAMERA/LIDAR=true, false
+#  HEADLESS/CAMERA/LIDAR/RECORD_ROSBAG=true, false
 ```
 
 On a laptop, start the `ground-image` (QGC, Zenoh, SSH, and GStreamer):

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -133,8 +133,17 @@ windows:
   <% if record_rosbag %>
   <%
     # Topics recorded when record_rosbag is true (opt-in: add the names of the topics to save)
+    rosbag_topics = %W[
+      /tf
+      /tf_static
+      /rosout
+      /detections
+      /dtc_commands
+      /tracks
+      /offboard_flag
+      /kiss/odometry
+    ]
     # Omitted for size: /lidar_points, /kiss/{frame,local_map,keypoints}, /camera_frames_*, /clock, /gimbal_state
-    rosbag_topics = %w[/tf /tf_static /rosout /detections /dtc_commands /tracks /offboard_flag /kiss/odometry]
     rosbag_topics += (1..10).map { |peer_id| "/state_sharing_drone_#{peer_id}" } # Up to 10 drones
     case autopilot
     when 'px4'
@@ -144,7 +153,11 @@ windows:
         /Drone#{drone_id}/fmu/out/vehicle_global_position
       ]
     when 'ardupilot'
-      rosbag_topics += %w[/mavros/state /mavros/local_position/odom /mavros/global_position/global]
+      rosbag_topics += %W[
+        /mavros/state
+        /mavros/local_position/odom
+        /mavros/global_position/global
+      ]
     end
   %>
   - logging:

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -150,7 +150,7 @@ windows:
   - logging:
       layout: tiled
       panes:
-        - mkdir -p /aas/rosbags && cd /aas/rosbags && ros2 bag record <%= rosbag_topics.join(' ') %> -s mcap -b 1000000000 <%= simulated_time ? '--use-sim-time' : '' %>
+        - mkdir -p /aas/rosbags && cd /aas/rosbags && ros2 bag record <%= rosbag_topics.join(' ') %> -s mcap <%= simulated_time ? '--use-sim-time' : '' %>
   <% end %>
 
   <% if gymnasium %>

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -132,7 +132,7 @@ windows:
 
   <% if record_rosbag %>
   <%
-    # Topics recorded when record_rosbag is true (opt-in, add what to save)
+    # Topics recorded when record_rosbag is true (opt-in: add the names of the topics to save)
     # Omitted for size: /lidar_points, /kiss/{frame,local_map,keypoints}, /camera_frames_*, /clock, /gimbal_state
     rosbag_topics = %w[/tf /tf_static /rosout /detections /dtc_commands /tracks /offboard_flag /kiss/odometry]
     rosbag_topics += (1..10).map { |peer_id| "/state_sharing_drone_#{peer_id}" } # Up to 10 drones

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -131,10 +131,26 @@ windows:
   <% end %>
 
   <% if record_rosbag %>
+  <%
+    # Topics recorded when record_rosbag is true (opt-in, add what to save)
+    # Omitted for size: /lidar_points, /kiss/{frame,local_map,keypoints}, /camera_frames_*, /clock, /gimbal_state
+    rosbag_topics = %w[/tf /tf_static /rosout /detections /dtc_commands /tracks /offboard_flag /kiss/odometry]
+    rosbag_topics += (1..10).map { |peer_id| "/state_sharing_drone_#{peer_id}" } # Up to 10 drones
+    case autopilot
+    when 'px4'
+      rosbag_topics += %W[
+        /Drone#{drone_id}/fmu/out/vehicle_status_v1
+        /Drone#{drone_id}/fmu/out/vehicle_local_position_v1
+        /Drone#{drone_id}/fmu/out/vehicle_global_position
+      ]
+    when 'ardupilot'
+      rosbag_topics += %w[/mavros/state /mavros/local_position/odom /mavros/global_position/global]
+    end
+  %>
   - logging:
       layout: tiled
       panes:
-        - mkdir -p /aas/rosbags && cd /aas/rosbags && ros2 bag record -a
+        - mkdir -p /aas/rosbags && cd /aas/rosbags && ros2 bag record <%= rosbag_topics.join(' ') %> -s mcap -b 1000000000 <%= simulated_time ? '--use-sim-time' : '' %>
   <% end %>
 
   <% if gymnasium %>

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -133,6 +133,7 @@ windows:
   <% if record_rosbag %>
   <%
     # Topics recorded when record_rosbag is true (opt-in: add the names of the topics to save)
+    # Omitted for size: /lidar_points, /kiss/{frame,local_map,keypoints}, /camera_frames_*, /clock, /gimbal_state
     rosbag_topics = %W[
       /tf
       /tf_static
@@ -143,7 +144,6 @@ windows:
       /offboard_flag
       /kiss/odometry
     ]
-    # Omitted for size: /lidar_points, /kiss/{frame,local_map,keypoints}, /camera_frames_*, /clock, /gimbal_state
     rosbag_topics += (1..10).map { |peer_id| "/state_sharing_drone_#{peer_id}" } # Up to 10 drones
     case autopilot
     when 'px4'

--- a/aircraft/aircraft_resources/scripts/analyze_bag.sh
+++ b/aircraft/aircraft_resources/scripts/analyze_bag.sh
@@ -12,13 +12,12 @@ tmux send-keys -t "$TMUX_PANE" C-c
 echo "Waiting for bag file to write metadata..."
 sleep 2
 
-# Find the most recently created bag directory
-LATEST_BAG_DIR=$(ls -t "$BAG_PARENT_DIR" | head -n 1)
-FULL_BAG_PATH="${BAG_PARENT_DIR}/${LATEST_BAG_DIR}"
+# Find the most recently created bag file
+FULL_BAG_PATH=$(ls -t "$BAG_PARENT_DIR"/*/*.mcap 2>/dev/null | head -n 1)
 
-if [ -d "$FULL_BAG_PATH" ]; then
+if [ -f "$FULL_BAG_PATH" ]; then
     echo "Launching PlotJuggler with bag: $FULL_BAG_PATH"
-    ros2 run plotjuggler plotjuggler "$FULL_BAG_PATH"
+    ros2 run plotjuggler plotjuggler -d "$FULL_BAG_PATH"
 else
     echo "Error: No bag file found in $BAG_PARENT_DIR"
     exit 1

--- a/aircraft/aircraft_resources/scripts/analyze_bag.sh
+++ b/aircraft/aircraft_resources/scripts/analyze_bag.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Analyze an aircraft's rosbag using PlotJuggler
-# To use this script, enable RECORD_ROSBAG in 'aircraft.yml.erb'
+# To use this script, set RECORD_ROSBAG=true when running sim_run.sh or deploy_run.sh
 
 TMUX_PANE="logging.0" # The tmux <window_name>.<pane_index> where the recording is happening
 BAG_PARENT_DIR="/aas/rosbags" # The directory where bags are saved

--- a/tools_and_docs/deploy_run.sh
+++ b/tools_and_docs/deploy_run.sh
@@ -26,6 +26,7 @@ GROUND_ID="${GROUND_ID:-101}" # Last byte of the ground container IP (default = 
 DRONE_TYPE="${DRONE_TYPE:-quad}" # Options: quad (default), vtol, tail
 DRONE_ID="${DRONE_ID:-1}" # Id of aircraft (default = 1)
 #
+RECORD_ROSBAG="${RECORD_ROSBAG:-false}" # Options: true, false (default)
 DEV="${DEV:-false}" # Options: true, false (default)
 HITL="${HITL:-false}" # Options: true, false (default)
 GND_CONTAINER="${GND_CONTAINER:-true}" # Options: true (default), false
@@ -45,7 +46,7 @@ check_enum AUTOPILOT px4 ardupilot
 check_enum ODOM none openvins fastlio superodom mimosa
 check_enum DRONE_TYPE quad vtol tail
 check_int DRONE_ID 1 99
-for v in HEADLESS CAMERA LIDAR DEV HITL GND_CONTAINER GROUND; do check_enum "$v" true false; done
+for v in HEADLESS CAMERA LIDAR RECORD_ROSBAG DEV HITL GND_CONTAINER GROUND; do check_enum "$v" true false; done
 for v in NUM_QUADS NUM_VTOLS NUM_TAILS; do check_int "$v" 0 99; done
 for v in SIM_ID GROUND_ID; do check_int "$v" 100 101; done
 print_envvars
@@ -117,10 +118,12 @@ docker run $DOCKER_RUN_FLAGS \
   --env GND_CONTAINER=$GND_CONTAINER \
   --env ROS_DOMAIN_ID=$DRONE_ID \
   --env REMOTE_VIDEO_STREAMS=true \
+  --env RECORD_ROSBAG=$RECORD_ROSBAG \
   --net=host \
   --privileged \
   --name aircraft-container_$DRONE_ID \
   --volume ~/Downloads/:/aas/mounted_downloads_folder \
+  --volume ~/Downloads/aas_rosbags:/aas/rosbags \
   ${DEV_OPTS} \
   ${AAS_SSH_OPTS} \
   aircraft-image

--- a/tools_and_docs/docker/aircraft.dockerfile
+++ b/tools_and_docs/docker/aircraft.dockerfile
@@ -386,7 +386,7 @@ RUN pip3 install --no-cache-dir --upgrade pip \
 # Check with $ python3 -c "import pymavlink; print(pymavlink.__version__)"
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ros-humble-plotjuggler \
-    ros-humble-plotjuggler-ros \
+    ros-humble-plotjuggler-ros ros-humble-rosbag2-storage-mcap \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tools_and_docs/sim_run.sh
+++ b/tools_and_docs/sim_run.sh
@@ -20,6 +20,7 @@ NUM_VTOLS="${NUM_VTOLS:-0}" # Number of VTOLs (default = 0)
 NUM_TAILS="${NUM_TAILS:-0}" # Number of tailsitters (default = 0)
 WORLD="${WORLD:-impalpable_greyness}" # Options: impalpable_greyness (default), apple_orchard, crematoria, shibuya_crossing, swiss_town, waterworld
 #
+RECORD_ROSBAG="${RECORD_ROSBAG:-false}" # Options: true, false (default)
 DEV="${DEV:-false}" # Options: true, false (default)
 HITL="${HITL:-false}" # Options: true, false (default)
 GND_CONTAINER="${GND_CONTAINER:-true}" # Options: true (default), false
@@ -48,7 +49,7 @@ source "${SCRIPT_DIR}/tests/check_env_vars.sh"
 check_enum AUTOPILOT px4 ardupilot
 check_enum ODOM none openvins fastlio superodom mimosa
 check_enum WORLD impalpable_greyness apple_orchard crematoria shibuya_crossing swiss_town waterworld
-for v in HEADLESS CAMERA LIDAR DEV HITL GND_CONTAINER START_AS_PAUSED PLOT; do check_enum "$v" true false; done
+for v in HEADLESS CAMERA LIDAR RECORD_ROSBAG DEV HITL GND_CONTAINER START_AS_PAUSED PLOT; do check_enum "$v" true false; done
 for v in NUM_QUADS NUM_VTOLS NUM_TAILS; do check_int "$v" 0 99; done
 for v in SIM_ID GROUND_ID; do check_int "$v" 100 101; done
 check_int INSTANCE 0 99
@@ -209,6 +210,7 @@ if [[ "$HITL" == "false" ]]; then
         --env SIM_SUBNET=$SIM_SUBNET --env AIR_SUBNET=$AIR_SUBNET --env SIM_ID=$SIM_ID --env GROUND_ID=$GROUND_ID \
         --env GND_CONTAINER=$GND_CONTAINER \
         --env ROS_DOMAIN_ID=$DRONE_ID \
+        --env RECORD_ROSBAG=$RECORD_ROSBAG \
         --net=$SIM_NET_NAME --ip=${SIM_SUBNET}.90.$DRONE_ID \
         --privileged \
         --name $NAME_AIRCRAFT_CNT"
@@ -264,6 +266,23 @@ cleanup() {
       echo "No log found for drone $i"
     fi
   done
+  # Copy the aircraft rosbags, if any were recorded
+  if [[ "$RECORD_ROSBAG" == "true" ]]; then
+    for i in $(seq 1 $NUM_DRONES); do
+      docker exec "aircraft-container-inst${INSTANCE}_${i}" tmux send-keys -t logging.0 C-c >/dev/null 2>&1 || true
+    done
+    sleep 2 # Wait for ros2 bag to write metadata.yaml
+    for i in $(seq 1 $NUM_DRONES); do
+      AIR_CNT="aircraft-container-inst${INSTANCE}_${i}"
+      LATEST_BAG=$(docker exec "$AIR_CNT" bash -c "ls -td /aas/rosbags/* 2>/dev/null | head -n 1" || true)
+      if [ -n "$LATEST_BAG" ]; then
+        docker cp "${AIR_CNT}:${LATEST_BAG}" "${PLOT_DIR}/drone_${i}_rosbag" >/dev/null 2>&1 \
+          && echo "Copied drone $i rosbag: $(basename "$LATEST_BAG")" || echo "Could not copy the rosbag of drone $i"
+      else
+        echo "No rosbag found for drone $i"
+      fi
+    done
+  fi
   # Cleanup
   DOCKER_PIDS=$(pgrep -f "docker run.*inst${INSTANCE}([^0-9]|$)" 2>/dev/null || true)
   CONTAINER_NAMES=("${SIM_CONT_NAME}" "${GND_CONT_NAME}" "aircraft-container-inst${INSTANCE}")

--- a/tools_and_docs/sim_run.sh
+++ b/tools_and_docs/sim_run.sh
@@ -266,17 +266,17 @@ cleanup() {
       echo "No log found for drone $i"
     fi
   done
-  # Copy the aircraft rosbags, if any were recorded
+  # Copy the aircraft rosbags (if recorded) to the host
   if [[ "$RECORD_ROSBAG" == "true" ]]; then
     for i in $(seq 1 $NUM_DRONES); do
       docker exec "aircraft-container-inst${INSTANCE}_${i}" tmux send-keys -t logging.0 C-c >/dev/null 2>&1 || true
     done
     sleep 2 # Wait for ros2 bag to write metadata.yaml
     for i in $(seq 1 $NUM_DRONES); do
-      AIR_CNT="aircraft-container-inst${INSTANCE}_${i}"
-      LATEST_BAG=$(docker exec "$AIR_CNT" bash -c "ls -td /aas/rosbags/* 2>/dev/null | head -n 1" || true)
+      AIR_CONT="aircraft-container-inst${INSTANCE}_${i}"
+      LATEST_BAG=$(docker exec "$AIR_CONT" bash -c "ls -td /aas/rosbags/* 2>/dev/null | head -n 1" || true)
       if [ -n "$LATEST_BAG" ]; then
-        docker cp "${AIR_CNT}:${LATEST_BAG}" "${PLOT_DIR}/drone_${i}_rosbag" >/dev/null 2>&1 \
+        docker cp "${AIR_CONT}:${LATEST_BAG}" "${PLOT_DIR}/drone_${i}_rosbag" >/dev/null 2>&1 \
           && echo "Copied drone $i rosbag: $(basename "$LATEST_BAG")" || echo "Could not copy the rosbag of drone $i"
       else
         echo "No rosbag found for drone $i"

--- a/tools_and_docs/sim_run.sh
+++ b/tools_and_docs/sim_run.sh
@@ -271,7 +271,7 @@ cleanup() {
     for i in $(seq 1 $NUM_DRONES); do
       docker exec "aircraft-container-inst${INSTANCE}_${i}" tmux send-keys -t logging.0 C-c >/dev/null 2>&1 || true
     done
-    sleep 2 # Wait for ros2 bag to write metadata.yaml
+    sleep 2 # Wait for ros2 bag to close the file and write metadata.yaml
     for i in $(seq 1 $NUM_DRONES); do
       AIR_CONT="aircraft-container-inst${INSTANCE}_${i}"
       LATEST_BAG=$(docker exec "$AIR_CONT" bash -c "ls -td /aas/rosbags/* 2>/dev/null | head -n 1" || true)


### PR DESCRIPTION
- [x]  `RECORD_ROSBAG=true` can now be set on `sim_run.sh` and `deploy_run.sh` (default `false`)
- [x] Bags are written as MCAP
- [x] `ros2 bag record -a` replaced with an explicit topic list in `aircraft.yml.erb`
- [x] `sim_run.sh` stops each rosbag recorder and copies its bag into the existing `logs/postmortem_*/` next to `drone_N.ulg` / `.BIN`
- [x] `deploy_run.sh` mounts `/aas/rosbags` to `~/Downloads/aas_rosbags`, so bags are written directly to the vehicle's disk
