### PR TITLE
Enhanced deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ On a laptop, start the `ground-image` (QGC, Zenoh, SSH, and GStreamer):
 cd aerial-autonomy-stack/tools_and_docs/
 
 ./sim_build.sh                                        # Build all images for amd64, including ground-image
-GROUND=true NUM_QUADS=1 AIR_SUBNET=10.223 HEADLESS=false ./deploy_run.sh
+GROUND=true QUAD_IDS=1 AIR_SUBNET=10.223 HEADLESS=false ./deploy_run.sh
 ```
 
 <details>
@@ -264,7 +264,7 @@ Set up a LAN on an arbitrary `SIM_SUBNET` with netmask `255.255.0.0` (e.g. `172.
 First, start the ground container:
 ```sh
 # On the computer with IPs ending in 90.101
-HITL=true GROUND=true NUM_QUADS=2 AIR_SUBNET=10.223 HEADLESS=false ./deploy_run.sh
+HITL=true GROUND=true QUAD_IDS=1,2 AIR_SUBNET=10.223 HEADLESS=false ./deploy_run.sh
 ```
 
 Then, start all aircraft containers, one on each Jetson (e.g. *via* SSH from the ground container):

--- a/aircraft/aircraft.yml.erb
+++ b/aircraft/aircraft.yml.erb
@@ -29,8 +29,7 @@
   hfov_deg = sensor_config['sensors']['camera_intrinsics']['horizontal_fov_deg'].to_f
   stereo_cam = sensor_config['sensors']['camera_intrinsics']['stereo'] == true
 
-  stereo_cam = false unless simulated_time # Stereo camera is for simulation only
-  camera_ids = stereo_cam ? [0, 1] : [0] # In simulation, these will be UDP ports 5600, 5601, etc.
+  camera_ids = stereo_cam ? [0, 1] : [0] # In SITL/HITL simulation, these are the UDP streams on ports 5600, 5601; on real drones, these are CSI sensor-id 0, 1
 %>
 
 name: drone
@@ -63,7 +62,7 @@ windows:
       panes:
         <% if camera %>
         <% camera_ids.each do |cam_id| %>
-        - until ros2 run yolo_py yolo_py --camera-id <%= cam_id %> <%= cam_id != 0 ? '--no-inference' : '' %> <% if odom != 'none' %>--ros2-frame-publisher<% end %> <%= headless ? '--headless' : '' %> <%= hitl ? '--hitl' : '' %> <%= remote_video_streams ? '--remote-video-streams' : '' %> <%= simulated_time ? "--ros-args -p use_sim_time:=true --hfov #{hfov_deg}" : '' %>; do sleep 2; done
+        - until ros2 run yolo_py yolo_py --camera-id <%= cam_id %> <%= cam_id != 0 ? '--no-inference' : '' %> <% if odom != 'none' %>--ros2-frame-publisher<% end %> <%= headless ? '--headless' : '' %> <%= hitl ? '--hitl' : '' %> <%= remote_video_streams && cam_id == 0 ? '--remote-video-streams' : '' %> <%= simulated_time ? "--ros-args -p use_sim_time:=true --hfov #{hfov_deg}" : '' %>; do sleep 2; done
         <% end %>
         <% end %>
         <% if lidar %>

--- a/aircraft/aircraft_ws/src/yolo_py/yolo_py/yolo_node.py
+++ b/aircraft/aircraft_ws/src/yolo_py/yolo_py/yolo_node.py
@@ -24,7 +24,7 @@ CONF_THRESH = 0.5
 
 class YoloInferenceNode(Node):
     def __init__(self, camera_id, headless, hitl, remote_video_streams, hfov, ros2_frame_publisher, no_inference):
-        super().__init__('yolo_inference_node')
+        super().__init__(f'yolo_inference_node_{camera_id}')
         self.camera_id = camera_id
         self.headless = headless
         self.hitl = hitl
@@ -64,7 +64,8 @@ class YoloInferenceNode(Node):
         self.bridge = CvBridge()
 
         # Create subscribers
-        self.create_subscription(Bool, 'enable_remote_video_streams', self.enable_remote_video_streams_callback, 1)
+        if self.remote_video_streams: # Only instances launched with --remote-video-streams (i.e. cam_id 0) subscribe to the stream toggle
+            self.create_subscription(Bool, 'enable_remote_video_streams', self.enable_remote_video_streams_callback, 1)
         
         self.get_logger().info("YOLO inference started.")
 

--- a/ground/ground.yml.erb
+++ b/ground/ground.yml.erb
@@ -3,10 +3,12 @@
 
   air_subnet = ENV.fetch('AIR_SUBNET', '10.22')
 
-  num_quads = ENV.fetch('NUM_QUADS', 1).to_i
-  num_vtols = ENV.fetch('NUM_VTOLS', 0).to_i
-  num_tails = ENV.fetch('NUM_TAILS', 0).to_i
-  num_drones = num_quads + num_vtols + num_tails
+  quad_ids = ENV.fetch('QUAD_IDS', '1').split(',').map(&:to_i)
+  vtol_ids = ENV.fetch('VTOL_IDS', '').split(',').map(&:to_i)
+  tail_ids = ENV.fetch('TAIL_IDS', '').split(',').map(&:to_i)
+  drone_ids = quad_ids + vtol_ids + tail_ids
+  num_drones = drone_ids.size
+  num_quads = quad_ids.size # Only used to auto-center QGC's virtual joystick in SITL/HITL with a single quad
 
   simulated_time = ENV.fetch('SIMULATED_TIME', 'false') == 'true'
   remote_video_streams = ENV.fetch('REMOTE_VIDEO_STREAMS', 'false') == 'true'
@@ -30,7 +32,7 @@ windows:
       layout: even-horizontal
       panes:
         - clear && echo "So nice to have you with us, this is the ground container."
-        - ros2 run ground_system ground_system --ros-args -p num_drones:=<%= num_drones %> -p base_port:=18540 -p rate:=10.0 <%= simulated_time ? '-p use_sim_time:=True' : '' %> -p assignments:="['1-0', '2-1']"
+        - ros2 run ground_system ground_system --ros-args -p drone_ids:="<%= drone_ids %>" -p base_port:=18540 -p rate:=10.0 <%= simulated_time ? '-p use_sim_time:=True' : '' %> -p assignments:="['1-0', '2-1']"
 
   - mavlink-router:
       layout: tiled
@@ -97,7 +99,7 @@ windows:
   - video_streams:
       layout: tiled
       panes:
-        <% (1..num_drones).each do |drone_id| %>
+        <% drone_ids.each do |drone_id| %>
         <% camera_ids.each do |cam_id| %>
         - until python3 /aas/ground_resources/comms/udp_gst_receiver.py --port <%= 5000 + drone_id + (cam_id * 100) %> --name "Aircraft <%= drone_id %> (Cam <%= cam_id %>)"; do sleep 2; done
         <% end %>
@@ -108,7 +110,7 @@ windows:
   - ssh_connections:
       layout: tiled
       panes:
-        <% (1..num_drones).each do |drone_id| %>
+        <% drone_ids.each do |drone_id| %>
         - |
           echo -e "\n\n Attach the AAS container with:\n\n\tdocker exec -it aircraft-container_<%= drone_id %> tmux attach\n\n"
           ssh -o ConnectTimeout=5 -o ServerAliveInterval=3 -o ServerAliveCountMax=3 orin@<%= "#{air_subnet}.90.#{drone_id}" %>

--- a/ground/ground.yml.erb
+++ b/ground/ground.yml.erb
@@ -14,14 +14,6 @@
   remote_video_streams = ENV.fetch('REMOTE_VIDEO_STREAMS', 'false') == 'true'
   ssh_connections = ENV.fetch('SSH_CONNECTIONS', 'false') == 'true'
   gnd_telem_baud = ENV.fetch('GND_TELEM_BAUD', '57600') # 57600 for SiK point-to-point, 230400 for Microhard point-to-multipoint with two drones
-
-  # Load sensor information from the sensor_config.yaml file
-  require 'yaml'
-  sensor_config = YAML.load_file('/aas/ground_resources/sensor_config.yaml')
-  stereo_cam = sensor_config['sensors']['camera_intrinsics']['stereo'] == true
-
-  stereo_cam = false unless simulated_time # Stereo camera is for simulation only
-  camera_ids = stereo_cam ? [0, 1] : [0]
 %>
 
 name: ground
@@ -100,9 +92,7 @@ windows:
       layout: tiled
       panes:
         <% drone_ids.each do |drone_id| %>
-        <% camera_ids.each do |cam_id| %>
-        - until python3 /aas/ground_resources/comms/udp_gst_receiver.py --port <%= 5000 + drone_id + (cam_id * 100) %> --name "Aircraft <%= drone_id %> (Cam <%= cam_id %>)"; do sleep 2; done
-        <% end %>
+        - until python3 /aas/ground_resources/comms/udp_gst_receiver.py --port <%= 5000 + drone_id %> --name "Aircraft <%= drone_id %> (Cam 0)"; do sleep 2; done
         <% end %>
   <% end %>
 

--- a/ground/ground_ws/src/drone_traffic_controller/drone_traffic_controller/dtc_controller_node.py
+++ b/ground/ground_ws/src/drone_traffic_controller/drone_traffic_controller/dtc_controller_node.py
@@ -32,12 +32,10 @@ class DTCController(Node):
         self.sub = self.create_subscription(SwarmObs, '/tracks', self.track_cb, 10)
         self.timer = self.create_timer(1.0, self.loop)
 
-        self.nq = int(os.environ.get('num_quads', os.environ.get('NUM_QUADS', '1')))
-        self.nv = int(os.environ.get('num_vtols', os.environ.get('NUM_VTOLS', '0')))
-        self.nt = int(os.environ.get('num_tails', os.environ.get('NUM_TAILS', '0')))
-        self.quad_ids = list(range(1, self.nq + 1))
-        self.vtol_ids = list(range(self.nq + 1, self.nq + self.nv + 1))
-        self.tail_ids = list(range(self.nq + self.nv + 1, self.nq + self.nv + self.nt + 1))
+        self.quad_ids = [int(i) for i in os.environ.get('QUAD_IDS', '1').split(',') if i]
+        self.vtol_ids = [int(i) for i in os.environ.get('VTOL_IDS', '').split(',') if i]
+        self.tail_ids = [int(i) for i in os.environ.get('TAIL_IDS', '').split(',') if i]
+        self.nq, self.nv, self.nt = len(self.quad_ids), len(self.vtol_ids), len(self.tail_ids)
         self.expected_ids = self.quad_ids + self.vtol_ids + self.tail_ids
         self.drones = {i: {'home': None, 'curr': None, 'alt': 0.0, 'target_enu': None, 'track_age': math.inf} for i in self.expected_ids}
         self.MAX_TRACK_AGE_SEC = 2.0 # Maximum acceptable age (in seconds) of track information to trigger an advance in the state machine

--- a/ground/ground_ws/src/ground_system/src/ground_system.cpp
+++ b/ground/ground_ws/src/ground_system/src/ground_system.cpp
@@ -3,7 +3,7 @@
 GroundSystem::GroundSystem() : Node("ground_system"), keep_running_(true)
 {
     // Declare Parameters
-    this->declare_parameter("num_drones", 1);
+    this->declare_parameter<std::vector<int64_t>>("drone_ids", std::vector<int64_t>{1});
     this->declare_parameter("ip", "0.0.0.0");
     this->declare_parameter("base_port", 18540);
     this->declare_parameter("rate", 10.0);
@@ -19,7 +19,7 @@ GroundSystem::GroundSystem() : Node("ground_system"), keep_running_(true)
     this->declare_parameter("simulated_link_outage_duration", 4.5); // s: max outage duration (uniform in [0, max])
 
     // Get Parameters
-    num_drones_ = static_cast<int>(this->get_parameter("num_drones").as_int());
+    drone_ids_ = this->get_parameter("drone_ids").as_integer_array();
     ip_ = this->get_parameter("ip").as_string();
     base_port_ = static_cast<int>(this->get_parameter("base_port").as_int());
     publish_rate_ = this->get_parameter("rate").as_double();
@@ -62,7 +62,7 @@ GroundSystem::GroundSystem() : Node("ground_system"), keep_running_(true)
 
     // Single listener thread, use base_port_ and pass drone_id = -1 to signal "auto-detect ID from message"
     listener_threads_.emplace_back(&GroundSystem::mavlink_listener, this, -1, base_port_, 0);
-    RCLCPP_INFO(this->get_logger(), "Listening to the streams from %d drones on single port %d", num_drones_, base_port_);
+    RCLCPP_INFO(this->get_logger(), "Listening to the streams from %zu drones on single port %d", drone_ids_.size(), base_port_);
     // To listen to separate UDP streams on separate ports, create multiple threads using:
     // listener_threads_.emplace_back(&GroundSystem::mavlink_listener, this, drone_id, port, thread_idx);
     // Make sure thread_idx < MAVLINK_COMM_NUM_BUFFERS
@@ -136,8 +136,8 @@ void GroundSystem::mavlink_listener(int drone_id, int port, int thread_idx)
                     int current_id = drone_id;
                     if (current_id == -1) {
                         current_id = msg.sysid;
-                        if (current_id < 1 || current_id > num_drones_) {
-                            continue; // Ignore out-of-bounds IDs
+                        if (std::find(drone_ids_.begin(), drone_ids_.end(), current_id) == drone_ids_.end()) {
+                            continue; // Ignore IDs not in drone_ids
                         }
                     }
                     

--- a/ground/ground_ws/src/ground_system/src/ground_system.hpp
+++ b/ground/ground_ws/src/ground_system/src/ground_system.hpp
@@ -45,7 +45,7 @@ public:
 
 private:
     // Parameters
-    int num_drones_;
+    std::vector<int64_t> drone_ids_;
     std::string ip_;
     int base_port_;
     double publish_rate_;

--- a/tools_and_docs/deploy_run.sh
+++ b/tools_and_docs/deploy_run.sh
@@ -33,9 +33,9 @@ GND_CONTAINER="${GND_CONTAINER:-true}" # Options: true (default), false
 
 # Only used by ground-container (i.e., if GROUND is true)
 GROUND="${GROUND:-false}" # Options: true, false (default)
-NUM_QUADS="${NUM_QUADS:-1}" # Number of quadcopters (default = 1)
-NUM_VTOLS="${NUM_VTOLS:-0}" # Number of VTOLs (default = 0)
-NUM_TAILS="${NUM_TAILS:-0}" # Number of tailsitters (default = 0)
+QUAD_IDS="${QUAD_IDS:-}" # Comma-separated DRONE_IDs of the quadcopters, e.g. QUAD_IDS=2,3 (default = none)
+VTOL_IDS="${VTOL_IDS:-}" # Comma-separated DRONE_IDs of the VTOLs, e.g. VTOL_IDS=5 (default = none)
+TAIL_IDS="${TAIL_IDS:-}" # Comma-separated DRONE_IDs of the tailsitters, e.g. TAIL_IDS=7,8 (default = none)
 
 # Find the script's path
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -47,7 +47,10 @@ check_enum ODOM none openvins fastlio superodom mimosa
 check_enum DRONE_TYPE quad vtol tail
 check_int DRONE_ID 1 99
 for v in HEADLESS CAMERA LIDAR RECORD_ROSBAG DEV HITL GND_CONTAINER GROUND; do check_enum "$v" true false; done
-for v in NUM_QUADS NUM_VTOLS NUM_TAILS; do check_int "$v" 0 99; done
+for v in QUAD_IDS VTOL_IDS TAIL_IDS; do [[ "${!v}" =~ ^([1-9][0-9]?(,[1-9][0-9]?)*)?$ ]] || abort "$v='${!v}', expected comma-separated IDs in 1..99"; done
+[[ -z $(echo "$QUAD_IDS,$VTOL_IDS,$TAIL_IDS" | tr ',' '\n' | grep . | sort | uniq -d) ]] || abort "Duplicate IDs in QUAD_IDS, VTOL_IDS, TAIL_IDS"
+if [[ "$GROUND" == "true" && -z "$QUAD_IDS$VTOL_IDS$TAIL_IDS" ]]; then abort "GROUND=true requires at least one ID in QUAD_IDS, VTOL_IDS, or TAIL_IDS"; fi
+for id in ${QUAD_IDS//,/ } ${VTOL_IDS//,/ } ${TAIL_IDS//,/ } $DRONE_ID; do (( id <= 10 )) || echo "WARNING: ID $id > 10 is not in the Zenoh peers and rosbag topics of aircraft.yml.erb" >&2; done
 for v in SIM_ID GROUND_ID; do check_int "$v" 100 101; done
 print_envvars
 
@@ -61,7 +64,7 @@ if [[ "$GROUND" == "true" ]]; then
     --volume /tmp/.X11-unix:/tmp/.X11-unix:rw \
     --env DISPLAY=$DISPLAY --env QT_X11_NO_MITSHM=1 --env XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR \
     --env HEADLESS=false \
-    --env NUM_QUADS=$NUM_QUADS --env NUM_VTOLS=$NUM_VTOLS --env NUM_TAILS=$NUM_TAILS \
+    --env QUAD_IDS=$QUAD_IDS --env VTOL_IDS=$VTOL_IDS --env TAIL_IDS=$TAIL_IDS \
     --env SIMULATED_TIME=$HITL \
     --env ROS_DOMAIN_ID=$GROUND_ID \
     --env AIR_SUBNET=$AIR_SUBNET \

--- a/tools_and_docs/docker/ground.dockerfile
+++ b/tools_and_docs/docker/ground.dockerfile
@@ -88,9 +88,6 @@ RUN bash -c "source /opt/ros/humble/setup.bash && (source /aas/github_ws/install
 COPY ground/ground_resources/ /aas/ground_resources
 COPY ground/ground_resources/patches/QGroundControl.ini /home/qgcuser/.config/QGroundControl/QGroundControl.ini
 
-# Copy sensor configuration
-COPY simulation/simulation_resources/aircraft_models/sensor_config.yaml /aas/ground_resources/sensor_config.yaml
-
 # Source the workspaces
 RUN echo "source /aas/ground_ws/install/setup.bash" >> /root/.bashrc
 # If needed (but already in .bashrc) $ source /opt/ros/humble/setup.bash && source /aas/ground_ws/install/setup.bash

--- a/tools_and_docs/sim_run.sh
+++ b/tools_and_docs/sim_run.sh
@@ -172,7 +172,9 @@ if [[ "$HITL" == "false" ]]; then
       --env DISPLAY=$DISPLAY --env QT_X11_NO_MITSHM=1 --env NVIDIA_DRIVER_CAPABILITIES=all --env XDG_RUNTIME_DIR=$XDG_RUNTIME_DIR --env GST_DEBUG=3 \
       --env __NV_PRIME_RENDER_OFFLOAD=1 --env __GLX_VENDOR_LIBRARY_NAME=nvidia \
       --env HEADLESS=$HEADLESS \
-      --env NUM_QUADS=$NUM_QUADS --env NUM_VTOLS=$NUM_VTOLS --env NUM_TAILS=$NUM_TAILS \
+      --env QUAD_IDS=$(seq -s, 1 $NUM_QUADS) \
+      --env VTOL_IDS=$(seq -s, $((NUM_QUADS + 1)) $((NUM_QUADS + NUM_VTOLS))) \
+      --env TAIL_IDS=$(seq -s, $((NUM_QUADS + NUM_VTOLS + 1)) $((NUM_QUADS + NUM_VTOLS + NUM_TAILS))) \
       --env SIMULATED_TIME=true \
       --env ROS_DOMAIN_ID=$GROUND_ID \
       --env HOST_INPUT_GID=$(getent group input | cut -d: -f3) \


### PR DESCRIPTION
New deployment features:

- [x] Non-contiguous drone ids for the deployment of the ground container
  - The ground container now takes `QUAD_IDS`, `VTOL_IDS` and `TAIL_IDS` instead of `NUM_QUADS`, `NUM_VTOLS` and `NUM_TAILS`: `GROUND=true ./deploy_run.sh` commands need updating (`sim_run.sh` converts automatically)
- [x] Stereo CSI cameras deployment
  - In HITL and deploy with dual CSI/stereo, the ground container now receives one stream per drone (removes the need to parse `sensor_config.yaml` in the ground container)