### PR TITLE
Allow Extra `docker build` Options From the Environment

### DIFF
--- a/tools_and_docs/deploy_build.sh
+++ b/tools_and_docs/deploy_build.sh
@@ -12,16 +12,16 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 BUILD_ADVANCED_ODOM="${BUILD_ADVANCED_ODOM:-false}" # Options: true, false (default), build the advanced odometry and SLAM packages
 CLEAN_BUILD="${CLEAN_BUILD:-false}" # Options: true, false (default), rebuild everything from scratch
 CLONE_ONLY="${CLONE_ONLY:-false}" # Options: true, false (default), clone the repos and skip the Docker builds
+BUILD_OPTS="${BUILD_OPTS:-}" # Extra options passed to every `docker build`, e.g. --add-host to point apt at a local mirror
 
 # Check env variables
 source "${SCRIPT_DIR}/tests/check_env_vars.sh"
 for v in BUILD_ADVANCED_ODOM CLEAN_BUILD CLONE_ONLY; do check_enum "$v" true false; done
 print_envvars
 
-BUILD_OPTS=""
 if [ "$CLEAN_BUILD" = "true" ]; then
   rm -rf "${SCRIPT_DIR}/../_github_clones"
-  BUILD_OPTS="--no-cache" # If CLEAN_BUILD is "true", rebuild everything from scratch
+  BUILD_OPTS="$BUILD_OPTS --no-cache" # If CLEAN_BUILD is "true", rebuild everything from scratch
   docker rmi aircraft-image:latest || true
   docker builder prune -f # Remove all dangling build cache to free up space
 fi

--- a/tools_and_docs/sim_build.sh
+++ b/tools_and_docs/sim_build.sh
@@ -10,16 +10,16 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 BUILD_ADVANCED_ODOM="${BUILD_ADVANCED_ODOM:-false}" # Options: true, false (default), build the advanced odometry and SLAM packages
 CLEAN_BUILD="${CLEAN_BUILD:-false}" # Options: true, false (default), rebuild everything from scratch
 CLONE_ONLY="${CLONE_ONLY:-false}" # Options: true, false (default), clone the repos and skip the Docker builds
+BUILD_OPTS="${BUILD_OPTS:-}" # Extra options passed to every `docker build`, e.g. --add-host to point apt at a local mirror
 
 # Check env variables
 source "${SCRIPT_DIR}/tests/check_env_vars.sh"
 for v in BUILD_ADVANCED_ODOM CLEAN_BUILD CLONE_ONLY; do check_enum "$v" true false; done
 print_envvars
 
-BUILD_OPTS=""
 if [ "$CLEAN_BUILD" = "true" ]; then
   rm -rf "${SCRIPT_DIR}/../_github_clones"
-  BUILD_OPTS="--no-cache" # If CLEAN_BUILD is "true", rebuild everything from scratch
+  BUILD_OPTS="$BUILD_OPTS --no-cache" # If CLEAN_BUILD is "true", rebuild everything from scratch
   docker rmi transitional-ros2-image:latest transitional-ros2-qgc-image:latest \
     aircraft-image:latest ground-image:latest simulation-image:latest || true
   docker builder prune -f # Remove all dangling build cache to free up space


### PR DESCRIPTION
`sim_build.sh` and `deploy_build.sh` hardcode `BUILD_OPTS=""`, so there is no way to pass anything to the `docker build` calls without editing the script.

The case that prompted this: on a network where `archive.ubuntu.com` times out, one `--add-host` pointing at a local mirror proxy fixes the apt fetches. No dockerfile change, and no rebuild either, since `--add-host` is not part of the layer cache key. 852 MB in 30 min before, seconds per index after.

- [x] `BUILD_OPTS` moves up into the defaults block beside `BUILD_ADVANCED_ODOM`/`CLEAN_BUILD`/`CLONE_ONLY`, so `print_envvars` reports it with no change to `check_env_vars.sh`
- [x] `CLEAN_BUILD=true` appends `--no-cache` instead of replacing, so the two combine
- [x] Both scripts, same edit
- [x] Default is empty, so nothing changes unless the variable is set

```sh
BUILD_OPTS="--add-host archive.ubuntu.com:172.17.0.1 --add-host security.ubuntu.com:172.17.0.1" ./sim_build.sh
```
